### PR TITLE
Adjusted ValidMovementTypes

### DIFF
--- a/mods/e2140/content/core/rules/defaults.yaml
+++ b/mods/e2140/content/core/rules/defaults.yaml
@@ -247,6 +247,7 @@
 		TargetTypes: Ground
 	# Vehicles have an animation while moving.
 	WithMoveAnimation:
+		ValidMovementTypes: Horizontal, Turn
 	# Voiced trait is defined per faction
 	# Group all vehicles in the map editor.
 	MapEditorData:


### PR DESCRIPTION
In the original game vehicles use `move` animation for turning. It is best visible for the mechs. Frankly, ORA engine supports that out of the box.