### PR TITLE
Added MT 200, MT 201L, adjusted explosions.

### DIFF
--- a/mods/e2140/content/ed/mod.yaml
+++ b/mods/e2140/content/ed/mod.yaml
@@ -10,6 +10,8 @@ Rules:
 	e2140|content/ed/buildings/tech_house/rules.yaml
 	e2140|content/ed/vehicles/st01b/rules.yaml
 	e2140|content/ed/vehicles/st02/rules.yaml
+	e2140|content/ed/vehicles/mt200/rules.yaml
+	e2140|content/ed/vehicles/mt201l/rules.yaml
 
 Sequences:
 	e2140|content/ed/sequences.yaml
@@ -18,6 +20,8 @@ Sequences:
 	e2140|content/ed/buildings/tech_house/sequences.yaml
 	e2140|content/ed/vehicles/st01b/sequences.yaml
 	e2140|content/ed/vehicles/st02/sequences.yaml
+	e2140|content/ed/vehicles/mt200/sequences.yaml
+	e2140|content/ed/vehicles/mt201l/sequences.yaml
 
 Voices:
 	e2140|content/ed/voices.yaml
@@ -25,3 +29,6 @@ Voices:
 Weapons:
 	e2140|content/ed/vehicles/st01b/weapons.yaml
 	e2140|content/ed/vehicles/st02/weapons.yaml
+	e2140|content/ed/vehicles/mt200/weapons.yaml
+	e2140|content/ed/vehicles/mt201l/weapons.yaml
+

--- a/mods/e2140/content/ed/vehicles/mt200/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/mt200/rules.yaml
@@ -1,0 +1,30 @@
+ed_vehicles_mt200:
+	Inherits@1: ^EdVehicle
+	Inherits@2: ^CoreTurret
+	Tooltip:
+		Name: MT 200
+	Valued:
+		Cost: 500
+	Buildable:
+		IconPalette:
+		Queue: Vehicle.ED
+		BuildDuration: 60
+	Health:
+		HP: 300
+	Mobile:
+		Speed: 91
+		TurnSpeed: 50
+	RevealsShroud:
+		Range: 3c768
+	Turreted:
+		TurnSpeed: 30
+		Offset: 0,0,160
+	Armament@PRIMARY:
+		Weapon: ed_vehicles_mt200
+		Recoil: 80
+		RecoilRecovery: 38
+		LocalOffset: 0,0,0
+		LocalYaw: 0, 0
+		MuzzlePalette:
+		MuzzleSequence: muzzle
+	WithMuzzleOverlay@muzzle:

--- a/mods/e2140/content/ed/vehicles/mt200/sequences.yaml
+++ b/mods/e2140/content/ed/vehicles/mt200/sequences.yaml
@@ -1,0 +1,22 @@
+ed_vehicles_mt200:
+	idle:
+		Filename: vehicle_tank_medium.vspr
+		Facings: -16
+	move:
+		Filename: vehicle_tank_medium.vspr
+		Start: 16
+		Length: 4
+		Facings: -16
+	turret:
+		Filename: turret_mt_200.vspr
+		Facings: -16
+		Offset: -1, 6, 0
+	muzzle:
+		Filename: turret_mt_200.vspr
+		Start: 16
+		Length: 3
+		Facings: -16
+		Offset: -1, 6, 0
+	icon:
+		Filename: SPRI0.MIX
+		Start: 135

--- a/mods/e2140/content/ed/vehicles/mt200/weapons.yaml
+++ b/mods/e2140/content/ed/vehicles/mt200/weapons.yaml
@@ -1,6 +1,6 @@
-ed_vehicles_st01b:
+ed_vehicles_mt200:
 	ReloadDelay: 40
-	Range: 3c768
+	Range: 5c0
 	MinRange: 0c512
 	Report: 3.smp
 	ValidTargets: Ground
@@ -15,7 +15,7 @@ ed_vehicles_st01b:
 		Shadow: False
 	Warhead@Damage: SpreadDamage
 		Spread: 128
-		Damage: 15
+		Damage: 25
 		ValidTargets: Ground
 	Warhead@Effect: CreateEffect
 		Image: projectile_cannon

--- a/mods/e2140/content/ed/vehicles/mt201l/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/mt201l/rules.yaml
@@ -1,0 +1,28 @@
+ed_vehicles_mt201l:
+	Inherits@1: ^EdVehicle
+	Inherits@2: ^CoreTurret
+	Tooltip:
+		Name: MT 201L
+	Valued:
+		Cost: 800
+	Buildable:
+		IconPalette:
+		Queue: Vehicle.ED
+		BuildDuration: 60
+	Health:
+		HP: 300
+	Mobile:
+		Speed: 91
+		TurnSpeed: 50
+	RevealsShroud:
+		Range: 3c768
+	Turreted:
+		TurnSpeed: 30
+		Offset: 0,0,0
+	Armament@PRIMARY:
+		Weapon: ed_vehicles_mt201l
+		Recoil: 80
+		RecoilRecovery: 38
+		LocalOffset: 350,0,50
+		LocalYaw: 0, 0
+		MuzzlePalette:

--- a/mods/e2140/content/ed/vehicles/mt201l/sequences.yaml
+++ b/mods/e2140/content/ed/vehicles/mt201l/sequences.yaml
@@ -1,0 +1,16 @@
+ed_vehicles_mt201l:
+	idle:
+		Filename: vehicle_tank_medium.vspr
+		Facings: -16
+	move:
+		Filename: vehicle_tank_medium.vspr
+		Start: 16
+		Length: 4
+		Facings: -16
+	turret:
+		Filename: turret_mt_201l.vspr
+		Facings: -16
+		Offset: -1, -2
+	icon:
+		Filename: SPRI0.MIX
+		Start: 136

--- a/mods/e2140/content/ed/vehicles/mt201l/weapons.yaml
+++ b/mods/e2140/content/ed/vehicles/mt201l/weapons.yaml
@@ -1,0 +1,25 @@
+ed_vehicles_mt201l:
+	ReloadDelay: 40
+	Range: 2c0
+	MinRange: 0c512
+	Report: 10.smp
+	ValidTargets: Ground
+	Burst: 10
+	BurstDelays: 3
+	Projectile: LaserZap
+		Duration: 5
+		ZOffset: 512
+		Width: 0c20
+		Color: FF4935
+		SecondaryBeam: True
+		SecondaryBeamWidth: 0c35
+		SecondaryBeamColor: FF4935
+	Warhead@Damage: SpreadDamage
+		Spread: 128
+		Damage: 8
+		ValidTargets: Ground
+	Warhead@Effect: CreateEffect
+		Image: smoke
+		Explosions: idle
+		ExplosionPalette:
+		ValidTargets: Ground

--- a/mods/e2140/content/ed/vehicles/mt201l/weapons.yaml
+++ b/mods/e2140/content/ed/vehicles/mt201l/weapons.yaml
@@ -7,6 +7,8 @@ ed_vehicles_mt201l:
 	Burst: 10
 	BurstDelays: 3
 	Projectile: LaserZap
+		HitAnimPalette:
+		LaunchEffectPalette:
 		Duration: 5
 		ZOffset: 512
 		Width: 0c20

--- a/mods/e2140/content/shared/mod.yaml
+++ b/mods/e2140/content/shared/mod.yaml
@@ -7,5 +7,6 @@ Rules:
 
 Sequences:
 	e2140|content/shared/sequences/projectiles.yaml
+	e2140|content/shared/sequences/misc.yaml
 	e2140|content/shared/vehicles/mcu/sequences.yaml
 	e2140|content/shared/buildings/power_plant/sequences.yaml

--- a/mods/e2140/content/shared/sequences/misc.yaml
+++ b/mods/e2140/content/shared/sequences/misc.yaml
@@ -1,0 +1,8 @@
+smoke:
+	Defaults:
+		Filename: smoke.vspr
+	idle:
+		BlendMode: Additive
+		Length: 8
+		Tick: 60
+		ZOffset: 512

--- a/mods/e2140/content/shared/sequences/projectiles.yaml
+++ b/mods/e2140/content/shared/sequences/projectiles.yaml
@@ -20,7 +20,14 @@ projectile_cannon:
 	explode:
 		BlendMode: Additive
 		Start: 1
-		Length: 5
+		Length: 8
+		Tick: 50
+		ZOffset: 512
+	explode2:
+		BlendMode: Additive
+		Start: 9
+		Length: 8
+		Tick: 50
 		ZOffset: 512
 
 projectile_heavy_rocket:
@@ -33,6 +40,11 @@ projectile_heavy_rocket:
 	explode:
 		BlendMode: Additive
 		Start: 16
+		Length: 8
+		ZOffset: 512
+	explode2:
+		BlendMode: Additive
+		Start: 24
 		Length: 8
 		ZOffset: 512
 

--- a/mods/e2140/maps/testmap_ed/map.yaml
+++ b/mods/e2140/maps/testmap_ed/map.yaml
@@ -105,18 +105,6 @@ Actors:
 		Owner: UCS_AI
 		Location: 6,21
 		Facing: 768
-	Actor18: ed_vehicles_st01b
-		Owner: ED_Player
-		Location: 23,6
-		Facing: 512
-	Actor26: ed_vehicles_st01b
-		Owner: ED_Player
-		Facing: 384
-		Location: 22,6
-	Actor27: ed_vehicles_st01b
-		Owner: ED_Player
-		Location: 24,7
-		Facing: 256
 	Actor28: ed_vehicles_st01b
 		Owner: ED_Player
 		Facing: 384
@@ -135,5 +123,70 @@ Actors:
 		Owner: ED_Player
 		Location: 22,3
 		Health: 31
+	Actor33: ed_vehicles_mt201l
+		Owner: ED_Player
+		Location: 26,8
+		TurretFacing: 0
+		Facing: 384
+	Actor34: ed_vehicles_mt201l
+		Owner: ED_Player
+		Facing: 384
+		Location: 27,8
+	Actor35: ed_vehicles_mt201l
+		Owner: ED_Player
+		Facing: 384
+		Location: 26,7
+	Actor36: ed_vehicles_mt201l
+		Owner: ED_Player
+		Facing: 384
+		Location: 27,7
+	Actor37: ed_vehicles_st02
+		Owner: ED_Player
+		Facing: 384
+		Location: 24,7
+	Actor38: ed_vehicles_st02
+		Owner: ED_Player
+		Facing: 384
+		Location: 23,7
+	Actor39: ed_vehicles_st02
+		Owner: ED_Player
+		Facing: 384
+		Location: 23,8
+	Actor40: ed_vehicles_st02
+		Owner: ED_Player
+		Facing: 384
+		Location: 24,8
+	Actor41: ed_vehicles_mt200
+		Owner: ED_Player
+		Facing: 384
+		Location: 21,7
+	Actor42: ed_vehicles_mt200
+		Owner: ED_Player
+		Facing: 384
+		Location: 20,7
+	Actor43: ed_vehicles_mt200
+		Owner: ED_Player
+		Facing: 384
+		Location: 20,8
+	Actor44: ed_vehicles_mt200
+		Owner: ED_Player
+		Facing: 384
+		Location: 21,8
+	Actor45: ed_vehicles_st01b
+		Owner: ED_Player
+		Facing: 384
+		Location: 18,7
+	Actor46: ed_vehicles_st01b
+		Owner: ED_Player
+		Facing: 384
+		Location: 17,7
+	Actor47: ed_vehicles_st01b
+		Owner: ED_Player
+		Facing: 384
+		Location: 17,8
+	Actor48: ed_vehicles_st01b
+		Owner: ED_Player
+		Facing: 384
+		Location: 18,8
 
 Rules: rules.yaml

--- a/mods/e2140/virtualassets/SPRM0.MIX.VirtualAssets.yaml
+++ b/mods/e2140/virtualassets/SPRM0.MIX.VirtualAssets.yaml
@@ -11,6 +11,7 @@ Generate:
 	projectile_heavy_rocket:
 		idle: 88-96 16
 		explode: 8-15
+		explode2: 0-7
 
 	projectile_plasma:
 		idle: 82
@@ -18,4 +19,8 @@ Generate:
 
 	projectile_cannon:
 		idle: 83
-		explode: 0-4
+		explode: 8-15
+		explode2: 0-7
+
+	smoke:
+		idle: 169-176


### PR DESCRIPTION
- Added MT 200
- Added MT 201L
- Cannon/Big missile projectile uses actually two explosion effects in vanilla Earth so I fixed.

Smoke is right now not moving due to wind not implemented yet.

LocalOffset for MT 200 is right now totally wrong and will need to be fixed in the future (in a nutshell, if `LocalOffset` is adjusted, then muzzle flash sprite is moved as well).