### PR TITLE
Corrected length of missile trail.

### DIFF
--- a/mods/e2140/content/shared/sequences/projectiles.yaml
+++ b/mods/e2140/content/shared/sequences/projectiles.yaml
@@ -53,7 +53,7 @@ missile_trail:
 		Tick: 70
 		BlendMode: Additive
 		Filename: missile_trail.vspr
-		Length: 3
+		Length: 4
 		ZOffset: 512
 
 projectile_plasma:

--- a/mods/e2140/virtualassets/SPRM0.MIX.VirtualAssets.yaml
+++ b/mods/e2140/virtualassets/SPRM0.MIX.VirtualAssets.yaml
@@ -6,7 +6,7 @@ Generate:
 		explode: 47-55
 
 	missile_trail: Smoke
-		idle: 157-159
+		idle: 157-160
 
 	projectile_heavy_rocket:
 		idle: 88-96 16


### PR DESCRIPTION
The correct length is 4, not 3.