### PR TITLE
Added warhead effects

### DIFF
--- a/mods/e2140/content/core/rules/defaults.yaml
+++ b/mods/e2140/content/core/rules/defaults.yaml
@@ -84,7 +84,7 @@
 		TerrainTypes: Clear, Road
 	# Constructions can be targeted by anything which attacks ground.
 	Targetable:
-		TargetTypes: Ground
+		TargetTypes: Ground, Structure
 	# In general all constructions can be selected.
 	Selectable:
 	# Constructions have sprites but do not use facing for them.
@@ -124,9 +124,6 @@
 	# Should not be auto attacked.
 	Targetable@NoAutoAttack:
 		TargetTypes: NoAutoAttack
-	# Target "Structure" target for ai.
-	Targetable:
-		TargetTypes: Ground, Structure
 	# Construction animation.
 	TransformSequence:
 		Image: core_buildingsequence_large
@@ -240,7 +237,7 @@
 		BlockedCursor: generic-blocked
 	# Actor can be targeted by anything which attacks ground.
 	Targetable:
-		TargetTypes: Ground
+		TargetTypes: Ground, Vehicle
 	# Vehicles have an animation while moving.
 	WithMoveAnimation:
 	# Group all vehicles in the map editor.

--- a/mods/e2140/content/ed/vehicles/btti/weapons.yaml
+++ b/mods/e2140/content/ed/vehicles/btti/weapons.yaml
@@ -3,9 +3,9 @@ ed_vehicles_btti:
 	Burst: 5
 	Range: 2c896
 	Report: 2.smp
-	ValidTargets: Ground
+	ValidTargets: Ground, Water
 	Projectile: InstantHit
 	Warhead@1Dam: SpreadDamage
-		Spread: 128
+		Spread: 24
 		Damage: 7
 		ValidTargets: Ground

--- a/mods/e2140/content/ed/vehicles/ht33r/weapons.yaml
+++ b/mods/e2140/content/ed/vehicles/ht33r/weapons.yaml
@@ -3,7 +3,7 @@ ed_vehicles_ht33r:
 	Range: 6c896
 	MinRange: 0c512
 	Report: 4.smp
-	ValidTargets: Ground
+	ValidTargets: Ground, Water
 	Burst: 3
 	BurstDelays: 25
 	Projectile: Missile
@@ -29,3 +29,16 @@ ed_vehicles_ht33r:
 		ExplosionPalette:
 		ImpactSounds: 15.smp, 16.smp
 		ValidTargets: Ground
+	Warhead@EffectRubble: CreateEffect
+		Image: rubble_big
+		Explosions: idle
+		ExplosionPalette:
+		ValidTargets: Ground
+		InvalidTargets: Vehicle, Structure
+	Warhead@EffectWater: CreateEffect
+		Image: water_splash
+		Explosions: idle
+		ExplosionPalette:
+		ImpactSounds: 20.smp, 21.smp
+		ValidTargets: Water
+		InvalidTargets: Vehicle, Structure

--- a/mods/e2140/content/ed/vehicles/mt200/weapons.yaml
+++ b/mods/e2140/content/ed/vehicles/mt200/weapons.yaml
@@ -3,7 +3,7 @@ ed_vehicles_mt200:
 	Range: 5c896
 	MinRange: 0c512
 	Report: 3.smp
-	ValidTargets: Ground
+	ValidTargets: Ground, Water
 	Burst: 4
 	BurstDelays: 20
 	Projectile: Bullet
@@ -23,3 +23,16 @@ ed_vehicles_mt200:
 		ExplosionPalette:
 		ImpactSounds: 15.smp
 		ValidTargets: Ground
+	Warhead@EffectRubble: CreateEffect
+		Image: rubble_small
+		Explosions: idle
+		ExplosionPalette:
+		ValidTargets: Ground
+		InvalidTargets: Vehicle, Structure
+	Warhead@EffectWater: CreateEffect
+		Image: water_splash
+		Explosions: idle
+		ExplosionPalette:
+		ImpactSounds: 20.smp, 21.smp
+		ValidTargets: Water
+		InvalidTargets: Vehicle, Structure

--- a/mods/e2140/content/ed/vehicles/mt201l/weapons.yaml
+++ b/mods/e2140/content/ed/vehicles/mt201l/weapons.yaml
@@ -3,7 +3,7 @@ ed_vehicles_mt201l:
 	Range: 2c896
 	MinRange: 0c512
 	Report: 10.smp
-	ValidTargets: Ground
+	ValidTargets: Ground, Water
 	Burst: 10
 	BurstDelays: 3
 	Projectile: LaserZap
@@ -24,4 +24,4 @@ ed_vehicles_mt201l:
 		Image: smoke
 		Explosions: idle
 		ExplosionPalette:
-		ValidTargets: Ground
+		ValidTargets: Ground, Water

--- a/mods/e2140/content/ed/vehicles/st01b/weapons.yaml
+++ b/mods/e2140/content/ed/vehicles/st01b/weapons.yaml
@@ -3,7 +3,7 @@ ed_vehicles_st01b:
 	Range: 3c896
 	MinRange: 0c512
 	Report: 3.smp
-	ValidTargets: Ground
+	ValidTargets: Ground, Water
 	Burst: 4
 	BurstDelays: 20
 	Projectile: Bullet
@@ -23,3 +23,16 @@ ed_vehicles_st01b:
 		ExplosionPalette:
 		ImpactSounds: 15.smp
 		ValidTargets: Ground
+	Warhead@EffectRubble: CreateEffect
+		Image: rubble_small
+		Explosions: idle
+		ExplosionPalette:
+		ValidTargets: Ground
+		InvalidTargets: Vehicle, Structure
+	Warhead@EffectWater: CreateEffect
+		Image: water_splash
+		Explosions: idle
+		ExplosionPalette:
+		ImpactSounds: 20.smp, 21.smp
+		ValidTargets: Water
+		InvalidTargets: Vehicle, Structure

--- a/mods/e2140/content/ed/vehicles/st02/weapons.yaml
+++ b/mods/e2140/content/ed/vehicles/st02/weapons.yaml
@@ -3,7 +3,7 @@ ed_vehicles_st02:
 	Range: 4c896
 	MinRange: 0c512
 	Report: 5.smp
-	ValidTargets: Ground
+	ValidTargets: Ground, Water
 	Burst: 3
 	BurstDelays: 8
 	Projectile: Missile
@@ -29,3 +29,10 @@ ed_vehicles_st02:
 		ExplosionPalette:
 		ImpactSounds: 14.smp
 		ValidTargets: Ground
+	Warhead@EffectWater: CreateEffect
+		Image: water_splash
+		Explosions: idle
+		ExplosionPalette:
+		ImpactSounds: 20.smp, 21.smp
+		ValidTargets: Water
+		InvalidTargets: Vehicle, Structure

--- a/mods/e2140/content/shared/sequences/misc.yaml
+++ b/mods/e2140/content/shared/sequences/misc.yaml
@@ -6,3 +6,25 @@ smoke:
 		Length: 8
 		Tick: 60
 		ZOffset: 512
+
+rubble_small:
+	Defaults:
+		Filename: rubble_small.vspr
+	idle:
+		Length: 5
+		Tick: 80
+
+rubble_big:
+	Defaults:
+		Filename: rubble_big.vspr
+	idle:
+		Length: 8
+		Tick: 100
+		Offset: 0,-10
+
+water_splash:
+	Defaults:
+		Filename: water_splash.vspr
+	idle:
+		Length: 8
+		Offset: 0,-10

--- a/mods/e2140/content/ucs/vehicles/bigmech/weapons.yaml
+++ b/mods/e2140/content/ucs/vehicles/bigmech/weapons.yaml
@@ -3,7 +3,7 @@ ucs_vehicles_big_mech:
 	Range: 5c896
 	MinRange: 0c512
 	Report: 5.smp
-	ValidTargets: Ground
+	ValidTargets: Ground, Water
 	Burst: 16
 	BurstDelays: 5
 	Projectile: Missile
@@ -29,3 +29,10 @@ ucs_vehicles_big_mech:
 		ExplosionPalette:
 		ImpactSounds: 14.smp
 		ValidTargets: Ground
+	Warhead@EffectWater: CreateEffect
+		Image: water_splash
+		Explosions: idle
+		ExplosionPalette:
+		ImpactSounds: 20.smp, 21.smp
+		ValidTargets: Water
+		InvalidTargets: Vehicle, Structure

--- a/mods/e2140/content/ucs/vehicles/raptor_ad/weapons.yaml
+++ b/mods/e2140/content/ucs/vehicles/raptor_ad/weapons.yaml
@@ -3,7 +3,7 @@ ucs_vehicles_raptor_ad:
 	Range: 4c896
 	MinRange: 0c512
 	Report: 5.smp
-	ValidTargets: Ground
+	ValidTargets: Ground, Water
 	Burst: 4
 	BurstDelays: 10
 	Projectile: Missile
@@ -29,3 +29,10 @@ ucs_vehicles_raptor_ad:
 		ExplosionPalette:
 		ImpactSounds: 14.smp
 		ValidTargets: Ground
+	Warhead@EffectWater: CreateEffect
+		Image: water_splash
+		Explosions: idle
+		ExplosionPalette:
+		ImpactSounds: 20.smp, 21.smp
+		ValidTargets: Water
+		InvalidTargets: Vehicle, Structure

--- a/mods/e2140/content/ucs/vehicles/raptor_es/weapons.yaml
+++ b/mods/e2140/content/ucs/vehicles/raptor_es/weapons.yaml
@@ -6,6 +6,6 @@ ucs_vehicles_raptor_es:
 	ValidTargets: Ground
 	Projectile: InstantHit
 	Warhead@1Dam: SpreadDamage
-		Spread: 128
+		Spread: 24
 		Damage: 7
 		ValidTargets: Ground

--- a/mods/e2140/content/ucs/vehicles/spider/weapons.yaml
+++ b/mods/e2140/content/ucs/vehicles/spider/weapons.yaml
@@ -3,7 +3,7 @@ ucs_vehicles_spider:
 	Range: 4c896
 	MinRange: 0c512
 	Report: 9.smp
-	ValidTargets: Ground
+	ValidTargets: Ground, Water
 	Burst: 12
 	BurstDelays: 5
 	Projectile: Bullet
@@ -23,3 +23,10 @@ ucs_vehicles_spider:
 		ExplosionPalette:
 		ImpactSounds: 22.smp
 		ValidTargets: Ground
+	Warhead@EffectWater: CreateEffect
+		Image: water_splash
+		Explosions: idle
+		ExplosionPalette:
+		ImpactSounds: 20.smp, 21.smp
+		ValidTargets: Water
+		InvalidTargets: Vehicle, Structure

--- a/mods/e2140/content/ucs/vehicles/spider_ii/weapons.yaml
+++ b/mods/e2140/content/ucs/vehicles/spider_ii/weapons.yaml
@@ -3,7 +3,7 @@ ucs_vehicles_spider_ii:
 	Range: 6c896
 	MinRange: 0c512
 	Report: 4.smp
-	ValidTargets: Ground
+	ValidTargets: Ground, Water
 	Burst: 4
 	BurstDelays: 10
 	Projectile: Missile
@@ -29,3 +29,16 @@ ucs_vehicles_spider_ii:
 		ExplosionPalette:
 		ImpactSounds: 14.smp
 		ValidTargets: Ground
+	Warhead@EffectRubble: CreateEffect
+		Image: rubble_big
+		Explosions: idle
+		ExplosionPalette:
+		ValidTargets: Ground
+		InvalidTargets: Vehicle, Structure
+	Warhead@EffectWater: CreateEffect
+		Image: water_splash
+		Explosions: idle
+		ExplosionPalette:
+		ImpactSounds: 20.smp, 21.smp
+		ValidTargets: Water
+		InvalidTargets: Vehicle, Structure

--- a/mods/e2140/content/ucs/vehicles/t100/weapons.yaml
+++ b/mods/e2140/content/ucs/vehicles/t100/weapons.yaml
@@ -3,9 +3,9 @@ ucs_vehicles_t100:
 	Burst: 10
 	Range: 3c896
 	Report: 2.smp
-	ValidTargets: Ground
+	ValidTargets: Ground, Water
 	Projectile: InstantHit
 	Warhead@1Dam: SpreadDamage
-		Spread: 128
+		Spread: 24
 		Damage: 7
 		ValidTargets: Ground

--- a/mods/e2140/content/ucs/vehicles/tiger_assault/weapons.yaml
+++ b/mods/e2140/content/ucs/vehicles/tiger_assault/weapons.yaml
@@ -3,7 +3,7 @@ ucs_vehicles_tiger_assault:
 	Range: 5c896
 	MinRange: 0c512
 	Report: 5.smp
-	ValidTargets: Ground
+	ValidTargets: Ground, Water
 	Burst: 4
 	BurstDelays: 10
 	Projectile: Missile
@@ -29,3 +29,10 @@ ucs_vehicles_tiger_assault:
 		ExplosionPalette:
 		ImpactSounds: 14.smp
 		ValidTargets: Ground
+	Warhead@EffectWater: CreateEffect
+		Image: water_splash
+		Explosions: idle
+		ExplosionPalette:
+		ImpactSounds: 20.smp, 21.smp
+		ValidTargets: Water
+		InvalidTargets: Vehicle, Structure

--- a/mods/e2140/virtualassets/SPRM0.MIX.VirtualAssets.yaml
+++ b/mods/e2140/virtualassets/SPRM0.MIX.VirtualAssets.yaml
@@ -24,3 +24,12 @@ Generate:
 
 	smoke:
 		idle: 169-176
+
+	rubble_small:
+		idle: 116-120
+
+	rubble_big:
+		idle: 137-144
+
+	water_splash:
+		idle: 149-156


### PR DESCRIPTION
- Added water splash effect.
- Added rubble effect.
- Added `Vehicle` target type, so rubble will not be spawned when a projectile hits vehicles or structures .
- Both structures and towers will now have by default Ground and Structure target types.
- Decreased spread for hitscan weapons.