### PR TITLE
Moved HCR M unit to `Building` queue.

### DIFF
--- a/mods/e2140/content/shared/vehicles/hcrm/rules.yaml
+++ b/mods/e2140/content/shared/vehicles/hcrm/rules.yaml
@@ -12,7 +12,7 @@ shared_vehicles_hcrm:
 		Cost: 800
 	Buildable:
 		IconPalette:
-		Queue: Vehicle.ED, Vehicle.UCS
+		Queue: Building.UCS, Building.ED
 		BuildDuration: 60
 	Selectable:
 		Bounds: 832, 656, 0, 0


### PR DESCRIPTION
It's faithful to vanilla this way.