### PR TITLE
Simplified turret turn speed.

### DIFF
--- a/mods/e2140/content/core/rules/defaults.yaml
+++ b/mods/e2140/content/core/rules/defaults.yaml
@@ -327,6 +327,7 @@
 ^CoreTurret:
 	# General turret behavior.
 	Turreted:
+		TurnSpeed: 30
 	# Special trait to position turret depending on attachment point (only visualy).
 	WithSpriteTurret:
 	# If it has a turret, it should attack with its turret only, meaning it can aim and fire with it while moving.

--- a/mods/e2140/content/ed/vehicles/ht33r/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/ht33r/rules.yaml
@@ -19,7 +19,6 @@ ed_vehicles_ht33r:
 	RevealsShroud:
 		Range: 6c896
 	Turreted:
-		TurnSpeed: 30
 		Offset: 0,0,160
 	Armament@PRIMARY:
 		Weapon: ed_vehicles_ht33r

--- a/mods/e2140/content/ed/vehicles/ht34j/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/ht34j/rules.yaml
@@ -19,7 +19,6 @@ ed_vehicles_ht34j:
 	RevealsShroud:
 		Range: 4c896
 	Turreted:
-		TurnSpeed: 30
 		Offset: 0,0,160
 	Armament@PRIMARY:
 		Weapon: ed_vehicles_ht34j

--- a/mods/e2140/content/ed/vehicles/mt200/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/mt200/rules.yaml
@@ -19,7 +19,6 @@ ed_vehicles_mt200:
 	RevealsShroud:
 		Range: 5c896
 	Turreted:
-		TurnSpeed: 30
 		Offset: 0,0,160
 	Armament@PRIMARY:
 		Weapon: ed_vehicles_mt200

--- a/mods/e2140/content/ed/vehicles/mt201l/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/mt201l/rules.yaml
@@ -19,7 +19,6 @@ ed_vehicles_mt201l:
 	RevealsShroud:
 		Range: 3c896
 	Turreted:
-		TurnSpeed: 30
 		Offset: 0,0,0
 	Armament@PRIMARY:
 		Weapon: ed_vehicles_mt201l

--- a/mods/e2140/content/ed/vehicles/st01b/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/st01b/rules.yaml
@@ -19,7 +19,6 @@ ed_vehicles_st01b:
 	RevealsShroud:
 		Range: 3c896
 	Turreted:
-		TurnSpeed: 30
 		Offset: 0,0,180
 	Armament@PRIMARY:
 		Weapon: ed_vehicles_st01b

--- a/mods/e2140/content/ed/vehicles/st02/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/st02/rules.yaml
@@ -19,7 +19,6 @@ ed_vehicles_st02:
 	RevealsShroud:
 		Range: 4c896
 	Turreted:
-		TurnSpeed: 30
 		Offset: 0,0,160
 	Armament@PRIMARY:
 		Weapon: ed_vehicles_st02

--- a/mods/e2140/content/ed/vehicles/warhammer/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/warhammer/rules.yaml
@@ -19,7 +19,6 @@ ed_vehicles_warhammer:
 	RevealsShroud:
 		Range: 5c896
 	Turreted:
-		TurnSpeed: 30
 		Offset: 0,0,0
 	AttackTurreted:
 		Armaments: primary, secondary, tertiary, quaternary

--- a/mods/e2140/content/ucs/vehicles/spider/rules.yaml
+++ b/mods/e2140/content/ucs/vehicles/spider/rules.yaml
@@ -18,7 +18,6 @@ ucs_vehicles_spider:
 	RevealsShroud:
 		Range: 4c896
 	Turreted:
-		TurnSpeed: 30
 		Offset: 0,0,200
 	Armament@PRIMARY:
 		Weapon: ucs_vehicles_spider

--- a/mods/e2140/content/ucs/vehicles/spider_ii/rules.yaml
+++ b/mods/e2140/content/ucs/vehicles/spider_ii/rules.yaml
@@ -14,7 +14,6 @@ ucs_vehicles_spider_ii:
 		HP: 400
 	Mobile:
 		Speed: 50
-		TurnSpeed: 30
 	RevealsShroud:
 		Range: 6c896
 	Turreted:

--- a/mods/e2140/content/ucs/vehicles/t100/rules.yaml
+++ b/mods/e2140/content/ucs/vehicles/t100/rules.yaml
@@ -19,7 +19,6 @@ ucs_vehicles_t100:
 	RevealsShroud:
 		Range: 2c896
 	Turreted:
-		TurnSpeed: 30
 		Offset: 0,0,0
 	Armament@PRIMARY:
 		Weapon: ucs_vehicles_t100

--- a/mods/e2140/content/ucs/vehicles/tiger_assault/rules.yaml
+++ b/mods/e2140/content/ucs/vehicles/tiger_assault/rules.yaml
@@ -18,7 +18,6 @@ ucs_vehicles_tiger_assault:
 	RevealsShroud:
 		Range: 5c896
 	Turreted:
-		TurnSpeed: 30
 		Offset: 0,0,200
 	Armament@PRIMARY:
 		Weapon: ucs_vehicles_tiger_assault


### PR DESCRIPTION
According to my observations, all actors in vanilla Earth 2140 have the same turret turn speed so it's best if `TurretSpeed` is moved to `defaults.yaml`.