### PR TITLE
Added ED aircrafts + improvements.

### DIFF
--- a/mods/e2140/chrome/cursors.yaml
+++ b/mods/e2140/chrome/cursors.yaml
@@ -30,6 +30,9 @@ Cursors:
 		enter:
 			Start: 8
 			Length: 4
+		enter-blocked:
+			Start: 24
+			Length: 4
 		exit:
 			Start: 20
 			Length: 4
@@ -51,6 +54,9 @@ Cursors:
 			Length: 4
 		deploy:
 			Start: 76
+			Length: 4
+		deploy-blocked:
+			Start: 24
 			Length: 4
 
 		waterMinePlace:

--- a/mods/e2140/content/core/rules/defaults.yaml
+++ b/mods/e2140/content/core/rules/defaults.yaml
@@ -299,18 +299,60 @@
 		Type: aircraft
 	# Making the actors actualy fly.
 	Aircraft:
-		CruiseAltitude: 2560
-		Repulsable: False # TODO verify what this is and if its correct
-	# Actor can be targeted by anything which attacks air.
-	Targetable:
+		IdleBehavior: Land
+		LandableTerrainTypes: Clear, Shore, Sand, Road
+		CruiseAltitude: 1c256
+		AltitudeVelocity: 0c60
+		IdealSeparation: 1c0
+		RepulsionSpeed: 50
+		AirborneCondition: airborne
+		VTOL: True
+	# Actor can be targeted by anything which attacks ground.
+	Targetable@Ground:
+		RequiresCondition: !airborne
+		TargetTypes: Ground, Vehicle
+		# Actor can be targeted by anything which attacks air.
+	Targetable@Airborne:
+		RequiresCondition: airborne
 		TargetTypes: Air
 	# Group all aircrafts in the map editor.
 	MapEditorData:
-		Categories: Aircraft
+		Categories: Vehicle
 	# Aircraft has visible shadow on ground beneath
-	WithShadow: # TODO verify this one. why 43? Shouldnt it be just "below"? And how does this work in combination with ZOffset?
-		Offset: 43,128,0
-		ZOffset: -129
+	WithShadow:
+		Offset: 0,32,0
+		ZOffset: -256
+		ShadowColor: 00000046
+	# Bla bla bla
+	RevealsShroud:
+		Type: GroundPosition
+	# Can guard and be guarded
+	Guard:
+		Voice: Escort
+	Guardable:
+	# This actor explodes when killed.
+	Explodes:
+		Weapon: VehicleExplosion
+		EmptyWeapon: VehicleExplosion
+		RequiresCondition: !airborne
+
+# Base for all aircrafts husks
+^CoreAircraftHusk:
+	Inherits: ^CoreAircraft
+	# Husks shouldn't be selectable in the map editor.
+	-MapEditorData:
+	# Husks shouldn't be selectable, only interctable.
+	-Selectable:
+	Interactable:
+	# Default health for aircraft husks
+	Health:
+		HP: 1000
+	# Aircraft husks fall to the ground and explode.
+	FallsToEarth:
+		Explosion: VehicleExplosion
+	# Aircraft husks are no longer targetable.
+	Targetable@Airborne:
+		TargetTypes: NoTarget
 
 # Special light vehicles
 ^CoreLightVehicle:
@@ -346,6 +388,19 @@
 	AttackFrontal:
 		FacingTolerance: 0
 		Voice: Attack
+	# Auto target enemies nearby.
+	AutoTarget:
+	AutoTargetPriority:
+		InvalidTargets: Structure
+
+# Grouped traits for standard non-turreted behavior.
+^CoreAttackAircraft:
+	# Allows aircrafts attacking strafe run way.
+	AttackAircraft:
+		FacingTolerance: 0
+		Voice: Attack
+		PersistentTargeting: false
+		OpportunityFire: false
 	# Auto target enemies nearby.
 	AutoTarget:
 	AutoTargetPriority:

--- a/mods/e2140/content/core/sequences/explosions.yaml
+++ b/mods/e2140/content/core/sequences/explosions.yaml
@@ -30,7 +30,7 @@ building_explosion:
 		Length: 5
 		Offset: 0,-20
 
-power_plant_explosion:
+nuclear_explosion:
 	idle:
 		Combine:
 			0:

--- a/mods/e2140/content/core/weapons/explosions.yaml
+++ b/mods/e2140/content/core/weapons/explosions.yaml
@@ -19,7 +19,7 @@ BuildingExplosion:
 PowerPlantExplosion:
 	ValidTargets: Ground, Water
 	Warhead@Effect: CreateEffect
-		Image: power_plant_explosion
+		Image: nuclear_explosion
 		Explosions: idle
 		ExplosionPalette:
 		ValidTargets: Ground, Water

--- a/mods/e2140/content/ed/aircrafts/hat/rules.yaml
+++ b/mods/e2140/content/ed/aircrafts/hat/rules.yaml
@@ -1,0 +1,35 @@
+ed_aircrafts_hat:
+	Inherits: ^EdAircraft
+	Tooltip:
+		Name: HAT
+	Valued:
+		Cost: 1000
+	Buildable:
+		IconPalette:
+		Queue: Vehicle.ED
+		BuildDuration: 60
+	Selectable:
+		Bounds: 1184, 1072, 0, 0
+	Health:
+		HP: 200
+	Aircraft:
+		Speed: 94
+		TurnSpeed: 50
+	RevealsShroud:
+		Range: 2c896
+	WithMoveAnimation:
+	Cargo:
+		Types: Infantry
+		MaxWeight: 6
+	SpawnActorOnDeath:
+		Actor: ed_aircrafts_hat_husk
+		RequiresCondition: airborne
+
+ed_aircrafts_hat_husk:
+	Inherits: ^CoreAircraftHusk
+	Tooltip:
+		Name: HAT
+	RevealsShroud:
+		Range: 4c896
+	RenderSprites: 
+		Image: ed_aircrafts_hat

--- a/mods/e2140/content/ed/aircrafts/hat/sequences.yaml
+++ b/mods/e2140/content/ed/aircrafts/hat/sequences.yaml
@@ -1,0 +1,33 @@
+ed_aircrafts_hat:
+	idle:
+		Filename: aircraft_hat.vspr
+		Start: 16
+		Length: 4
+		Tick: 60
+		Facings: -16
+	move:
+		Filename: aircraft_hat.vspr
+		Start: 16
+		Length: 4
+		Facings: -16
+	open:
+		Filename: aircraft_hat.vspr
+		Start: 80
+		Length: 4
+	unload:
+		Filename: aircraft_hat.vspr
+		Start: 82
+	icon:
+		Filename: SPRI0.MIX
+		Start: 160
+	# TODO: Enable after PR #20705 is merged in OpenRA
+	#icon-ucs:
+	#	Filename: SPRI1.MIX
+	#	Start: 160
+
+# TODO: remove after PR #20705
+ed_aircrafts_hat.ucs:
+	Inherits: ed_aircrafts_hat
+	icon:
+		Filename: SPRI1.MIX
+		Start: 160

--- a/mods/e2140/content/ed/aircrafts/nemezis/rules.yaml
+++ b/mods/e2140/content/ed/aircrafts/nemezis/rules.yaml
@@ -1,0 +1,38 @@
+ed_aircrafts_nemezis:
+	Inherits@1: ^EdAircraft
+	Inherits@2: ^CoreAttackAircraft
+	Tooltip:
+		Name: Heavy Bomber
+	Valued:
+		Cost: 2300
+	Buildable:
+		IconPalette:
+		Queue: Vehicle.ED
+		BuildDuration: 60
+	Selectable:
+		Bounds: 1680, 1648, 0, 0
+	Health:
+		HP: 300
+	Aircraft:
+		Speed: 94
+		TurnSpeed: 50
+	RevealsShroud:
+		Range: 3c896
+	Armament@PRIMARY:
+		Weapon: ed_aircrafts_nemezis
+		MuzzlePalette:
+	AttackAircraft:
+		StrafeRunLength: 6c0
+	WithMoveAnimation:
+	SpawnActorOnDeath:
+		Actor: ed_aircrafts_nemezis_husk
+		RequiresCondition: airborne
+
+ed_aircrafts_nemezis_husk:
+	Inherits: ^CoreAircraftHusk
+	Tooltip:
+		Name: Heavy Bomber
+	RevealsShroud:
+		Range: 3c896
+	RenderSprites: 
+		Image: ed_aircrafts_nemezis

--- a/mods/e2140/content/ed/aircrafts/nemezis/sequences.yaml
+++ b/mods/e2140/content/ed/aircrafts/nemezis/sequences.yaml
@@ -1,0 +1,22 @@
+ed_aircrafts_nemezis:
+	idle:
+		Filename: aircraft_nemezis.vspr
+		Facings: -16
+	move:
+		Filename: aircraft_nemezis.vspr
+		Start: 16
+		Facings: -16
+	icon:
+		Filename: SPRI0.MIX
+		Start: 276
+	# TODO: Enable after PR #20705 is merged in OpenRA
+	#icon-ucs:
+	#	Filename: SPRI1.MIX
+	#	Start: 276
+
+# TODO: remove after PR #20705
+ed_aircrafts_nemezis.ucs:
+	Inherits: ed_aircrafts_nemezis
+	icon:
+		Filename: SPRI1.MIX
+		Start: 276

--- a/mods/e2140/content/ed/aircrafts/nemezis/weapons.yaml
+++ b/mods/e2140/content/ed/aircrafts/nemezis/weapons.yaml
@@ -1,0 +1,20 @@
+ed_aircrafts_nemezis:
+	ReloadDelay: 500 	# TODO to be verified
+	Range: 0c512
+	ValidTargets: Ground, Water
+	Projectile: GravityBomb
+		Velocity: 0,0,-25
+		Shadow: True
+		Palette: 
+		Image: projectile_bomb
+		Sequences: idle
+	Warhead@Damage: SpreadDamage
+		Spread: 0c728
+		Damage: 1750
+		ValidTargets: Ground
+	Warhead@Effect: CreateEffect
+		Image: nuclear_explosion
+		Explosions: idle
+		ExplosionPalette:
+		ImpactSounds: 14.smp
+		ValidTargets: Ground

--- a/mods/e2140/content/ed/aircrafts/storm/rules.yaml
+++ b/mods/e2140/content/ed/aircrafts/storm/rules.yaml
@@ -1,0 +1,56 @@
+ed_aircrafts_storm:
+	Inherits@1: ^EdAircraft
+	Inherits@2: ^CoreAttackAircraft
+	Tooltip:
+		Name: STORM
+	Valued:
+		Cost: 500
+	Buildable:
+		IconPalette:
+		Queue: Vehicle.ED
+		BuildDuration: 60
+	Selectable:
+		Bounds: 1312, 928, 0, 0
+	Health:
+		HP: 40
+	Aircraft:
+		Speed: 175
+		TurnSpeed: 50
+	RevealsShroud:
+		Range: 5c896
+	Armament@PRIMARY:
+		Weapon: ed_aircrafts_storm
+		MuzzlePalette:
+		MuzzleSequence: muzzle
+		PauseOnCondition: !ammo
+	WithMuzzleOverlay@muzzle:
+	AmmoPool:
+		Ammo: 55
+		AmmoCondition: ammo
+	ReloadAmmoPool:
+		Delay: 56
+		ResetOnFire: True
+		Count: 50
+	WithIdleOverlay@rotorfast:
+		Offset: 0,16,48
+		Sequence: rotorfast
+		RequiresCondition: airborne
+	WithIdleOverlay@rotorslow:
+		Offset: 0,16,48
+		Sequence: rotorslow
+		RequiresCondition: !airborne
+	SpawnActorOnDeath:
+		Actor: ed_aircrafts_storm_husk
+		RequiresCondition: airborne
+
+ed_aircrafts_storm_husk:
+	Inherits: ^CoreAircraftHusk
+	Tooltip:
+		Name: STORM
+	RevealsShroud:
+		Range: 5c896
+	WithIdleOverlay@rotorslow:
+		Offset: 0,16,48
+		Sequence: rotorslow
+	RenderSprites: 
+		Image: ed_aircrafts_storm

--- a/mods/e2140/content/ed/aircrafts/storm/sequences.yaml
+++ b/mods/e2140/content/ed/aircrafts/storm/sequences.yaml
@@ -1,0 +1,33 @@
+ed_aircrafts_storm:
+	idle:
+		Filename: aircraft_storm.vspr
+		Facings: -16
+	move:
+		Filename: aircraft_storm.vspr
+		Facings: -16
+	rotorfast:
+		Filename: rotor_fast.vspr
+		Length: 2
+	rotorslow:
+		Filename: rotor_slow.vspr
+		Length: 4
+	muzzle:
+		Filename: aircraft_storm.vspr
+		Start: 16
+		Length: 3
+		Facings: -16
+		Tick: 60
+	icon:
+		Filename: SPRI0.MIX
+		Start: 161
+	# TODO: Enable after PR #20705 is merged in OpenRA
+	#icon-ucs:
+	#	Filename: SPRI1.MIX
+	#	Start: 161
+
+# TODO: remove after PR #20705
+ed_aircrafts_storm.ucs:
+	Inherits: ed_aircrafts_storm
+	icon:
+		Filename: SPRI1.MIX
+		Start: 161

--- a/mods/e2140/content/ed/aircrafts/storm/weapons.yaml
+++ b/mods/e2140/content/ed/aircrafts/storm/weapons.yaml
@@ -1,0 +1,31 @@
+ed_aircrafts_storm:
+	ReloadDelay: 56
+	Burst: 55
+	Range: 5c896
+	MinRange: 1c896
+	Report: 1.smp
+	ValidTargets: Ground, Water, Air
+	Projectile: InstantHit
+		Inaccuracy: 0c128
+	Warhead@1Dam: SpreadDamage
+		Spread: 24
+		Damage: 10
+		ValidTargets: Ground, Air
+	Warhead@Effect: CreateEffect
+		Image: rubble_firearm
+		Explosions: rubble_firearm1, rubble_firearm2, rubble_firearm3
+		ExplosionPalette:
+		ValidTargets: Ground
+		InvalidTargets: Vehicle, Structure
+	Warhead@EffectWater: CreateEffect
+		Image: water_splash_firearm
+		Explosions: idle
+		ExplosionPalette:
+		ImpactSounds: 20.smp, 21.smp
+		ValidTargets: Water
+		InvalidTargets: Vehicle, Structure
+	Warhead@EffectSmoke: CreateEffect
+		Image: smoke_firearm
+		Explosions: smoke_firearm1, smoke_firearm2, smoke_firearm3
+		ExplosionPalette:
+		ValidTargets: Vehicle, Structure, Air

--- a/mods/e2140/content/ed/aircrafts/thunder/rules.yaml
+++ b/mods/e2140/content/ed/aircrafts/thunder/rules.yaml
@@ -1,0 +1,47 @@
+ed_aircrafts_thunder:
+	Inherits@1: ^EdAircraft
+	Inherits@2: ^CoreAttackAircraft
+	Tooltip:
+		Name: THUNDER
+	Valued:
+		Cost: 700
+	Buildable:
+		IconPalette:
+		Queue: Vehicle.ED
+		BuildDuration: 60
+	Selectable:
+		Bounds: 1312, 928, 0, 0
+	Health:
+		HP: 40
+	Aircraft:
+		Speed: 175
+		TurnSpeed: 50
+	RevealsShroud:
+		Range: 4c896
+	Armament@PRIMARY:
+		Weapon: ed_aircrafts_thunder
+		LocalOffset: 0,100,-50, 0,-100,-50
+		MuzzlePalette:
+	WithIdleOverlay@rotorfast:
+		Offset: 0,16,48
+		Sequence: rotorfast
+		RequiresCondition: airborne
+	WithIdleOverlay@rotorslow:
+		Offset: 0,16,48
+		Sequence: rotorslow
+		RequiresCondition: !airborne
+	SpawnActorOnDeath:
+		Actor: ed_aircrafts_thunder_husk
+		RequiresCondition: airborne
+
+ed_aircrafts_thunder_husk:
+	Inherits: ^CoreAircraftHusk
+	Tooltip:
+		Name: THUNDER
+	RevealsShroud:
+		Range: 4c896
+	WithIdleOverlay@rotorslow:
+		Offset: 0,16,48
+		Sequence: rotorslow
+	RenderSprites: 
+		Image: ed_aircrafts_thunder

--- a/mods/e2140/content/ed/aircrafts/thunder/sequences.yaml
+++ b/mods/e2140/content/ed/aircrafts/thunder/sequences.yaml
@@ -1,0 +1,27 @@
+ed_aircrafts_thunder:
+	idle:
+		Filename: aircraft_thunder.vspr
+		Facings: -16
+	move:
+		Filename: aircraft_thunder.vspr
+		Facings: -16
+	rotorfast:
+		Filename: rotor_fast.vspr
+		Length: 2
+	rotorslow:
+		Filename: rotor_slow.vspr
+		Length: 4
+	icon:
+		Filename: SPRI0.MIX
+		Start: 159
+	# TODO: Enable after PR #20705 is merged in OpenRA
+	#icon-ucs:
+	#	Filename: SPRI1.MIX
+	#	Start: 161
+
+# TODO: remove after PR #20705
+ed_aircrafts_storm.ucs:
+	Inherits: ed_aircrafts_storm
+	icon:
+		Filename: SPRI1.MIX
+		Start: 159

--- a/mods/e2140/content/ed/aircrafts/thunder/weapons.yaml
+++ b/mods/e2140/content/ed/aircrafts/thunder/weapons.yaml
@@ -1,14 +1,14 @@
-ucs_vehicles_raptor_ad:
-	ReloadDelay: 62
+ed_aircrafts_thunder:
+	ReloadDelay: 50
 	Range: 4c896
 	MinRange: 0c512
 	Report: 5.smp
-	ValidTargets: Ground, Water, Air
-	Burst: 2
-	BurstDelays: 12
+	ValidTargets: Ground, Water
+	Burst: 3
+	BurstDelays: 8
 	Projectile: Missile
 		Speed: 260
-		Arm: 1
+		Arm: 2
 		Blockable: false
 		Inaccuracy: 128
 		Image: projectile_rocket
@@ -20,31 +20,27 @@ ucs_vehicles_raptor_ad:
 		ShadowColor: 00000046
 		HorizontalRateOfTurn: 20
 		RangeLimit: 6c0
-	Warhead@DamageGround: SpreadDamage
+	Warhead@Damage: SpreadDamage
 		Spread: 128
-		Damage: 25
+		Damage: 20
 		ValidTargets: Ground
-	Warhead@DamageAir: SpreadDamage
-		Spread: 128
-		Damage: 25
-		ValidTargets: Air
 	Warhead@EffectGround: CreateEffect
 		Image: projectile_rocket
 		Explosions: explode
 		ExplosionPalette:
 		ImpactSounds: 14.smp
 		ValidTargets: Ground
-		InvalidTargets: Vehicle, Structure, Air
+		InvalidTargets: Vehicle, Structure
 	Warhead@EffectActor: CreateEffect
 		Image: projectile_cannon
 		Explosions: explode, explode2
 		ExplosionPalette:
 		ImpactSounds: 15.smp
-		ValidTargets: Vehicle, Structure, Air
+		ValidTargets: Vehicle, Structure
 	Warhead@EffectWater: CreateEffect
 		Image: water_splash
 		Explosions: idle
 		ExplosionPalette:
 		ImpactSounds: 20.smp, 21.smp
 		ValidTargets: Water
-		InvalidTargets: Vehicle, Structure, Air
+		InvalidTargets: Vehicle, Structure

--- a/mods/e2140/content/ed/aircrafts/vtol/rules.yaml
+++ b/mods/e2140/content/ed/aircrafts/vtol/rules.yaml
@@ -1,0 +1,37 @@
+ed_aircrafts_vtol:
+	Inherits@1: ^EdAircraft
+	Inherits@2: ^CoreAttackAircraft
+	Tooltip:
+		Name: VTOL
+	Valued:
+		Cost: 900
+	Buildable:
+		IconPalette:
+		Queue: Vehicle.ED
+		BuildDuration: 60
+	Selectable:
+		Bounds: 992, 848, 0, 0
+	Health:
+		HP: 50
+	Aircraft:
+		Speed: 175
+		TurnSpeed: 50
+	RevealsShroud:
+		Range: 6c896
+	Armament@PRIMARY:
+		Weapon: ed_aircrafts_vtol
+		LocalOffset: 0,100,-50, 0,-100,-50
+		MuzzlePalette:
+	WithMoveAnimation:
+	SpawnActorOnDeath:
+		Actor: ed_aircrafts_vtol_husk
+		RequiresCondition: airborne
+
+ed_aircrafts_vtol_husk:
+	Inherits: ^CoreAircraftHusk
+	Tooltip:
+		Name: VTOL
+	RevealsShroud:
+		Range: 6c896
+	RenderSprites: 
+		Image: ed_aircrafts_vtol

--- a/mods/e2140/content/ed/aircrafts/vtol/sequences.yaml
+++ b/mods/e2140/content/ed/aircrafts/vtol/sequences.yaml
@@ -1,0 +1,22 @@
+ed_aircrafts_vtol:
+	idle:
+		Filename: aircraft_vtol.vspr
+		Facings: -16
+	move:
+		Filename: aircraft_vtol.vspr
+		Start: 16
+		Facings: -16
+	icon:
+		Filename: SPRI0.MIX
+		Start: 275
+	# TODO: Enable after PR #20705 is merged in OpenRA
+	#icon-ucs:
+	#	Filename: SPRI1.MIX
+	#	Start: 275
+
+# TODO: remove after PR #20705
+ed_aircrafts_storm.ucs:
+	Inherits: ed_aircrafts_vtol
+	icon:
+		Filename: SPRI1.MIX
+		Start: 275

--- a/mods/e2140/content/ed/aircrafts/vtol/weapons.yaml
+++ b/mods/e2140/content/ed/aircrafts/vtol/weapons.yaml
@@ -1,11 +1,11 @@
-ed_vehicles_ht33r:
-	ReloadDelay: 62
+ed_aircrafts_vtol:
+	ReloadDelay: 125 	# TODO to be verified
 	Range: 6c896
 	MinRange: 0c512
 	Report: 4.smp
-	ValidTargets: Ground, Water, Air
-	Burst: 3
-	BurstDelays: 24
+	ValidTargets: Ground, Water
+	Burst: 2
+	BurstDelays: 8 # TODO to be verified
 	Projectile: Missile
 		Speed: 260
 		Arm: 2
@@ -20,30 +20,26 @@ ed_vehicles_ht33r:
 		ShadowColor: 00000046
 		HorizontalRateOfTurn: 20
 		RangeLimit: 8c0
-	Warhead@DamageGround: SpreadDamage
+	Warhead@Damage: SpreadDamage
 		Spread: 128
 		Damage: 80
 		ValidTargets: Ground
-	Warhead@DamageAir: SpreadDamage
-		Spread: 128
-		Damage: 80
-		ValidTargets: Air
 	Warhead@Effect: CreateEffect
 		Image: projectile_cannon
 		Explosions: explode, explode2
 		ExplosionPalette:
 		ImpactSounds: 15.smp, 16.smp
-		ValidTargets: Ground, Air
+		ValidTargets: Ground
 	Warhead@EffectRubble: CreateEffect
 		Image: rubble_big
 		Explosions: idle
 		ExplosionPalette:
 		ValidTargets: Ground
-		InvalidTargets: Vehicle, Structure, Air
+		InvalidTargets: Vehicle, Structure
 	Warhead@EffectWater: CreateEffect
 		Image: water_splash
 		Explosions: idle
 		ExplosionPalette:
 		ImpactSounds: 20.smp, 21.smp
 		ValidTargets: Water
-		InvalidTargets: Vehicle, Structure, Air
+		InvalidTargets: Vehicle, Structure

--- a/mods/e2140/content/ed/mod.yaml
+++ b/mods/e2140/content/ed/mod.yaml
@@ -17,6 +17,11 @@ Rules:
 	e2140|content/ed/vehicles/ht34j/rules.yaml
 	e2140|content/ed/vehicles/warhammer/rules.yaml
 	e2140|content/ed/vehicles/screamer/rules.yaml
+	e2140|content/ed/aircrafts/storm/rules.yaml
+	e2140|content/ed/aircrafts/thunder/rules.yaml
+	e2140|content/ed/aircrafts/hat/rules.yaml
+	e2140|content/ed/aircrafts/vtol/rules.yaml
+	e2140|content/ed/aircrafts/nemezis/rules.yaml
 
 Sequences:
 	e2140|content/ed/sequences.yaml
@@ -32,6 +37,11 @@ Sequences:
 	e2140|content/ed/vehicles/ht34j/sequences.yaml
 	e2140|content/ed/vehicles/warhammer/sequences.yaml
 	e2140|content/ed/vehicles/screamer/sequences.yaml
+	e2140|content/ed/aircrafts/storm/sequences.yaml
+	e2140|content/ed/aircrafts/thunder/sequences.yaml
+	e2140|content/ed/aircrafts/hat/sequences.yaml
+	e2140|content/ed/aircrafts/vtol/sequences.yaml
+	e2140|content/ed/aircrafts/nemezis/sequences.yaml
 
 Voices:
 	e2140|content/ed/voices.yaml
@@ -45,3 +55,7 @@ Weapons:
 	e2140|content/ed/vehicles/ht33r/weapons.yaml
 	e2140|content/ed/vehicles/ht34j/weapons.yaml
 	e2140|content/ed/vehicles/warhammer/weapons.yaml
+	e2140|content/ed/aircrafts/storm/weapons.yaml
+	e2140|content/ed/aircrafts/thunder/weapons.yaml
+	e2140|content/ed/aircrafts/vtol/weapons.yaml
+	e2140|content/ed/aircrafts/nemezis/weapons.yaml

--- a/mods/e2140/content/ed/rules.yaml
+++ b/mods/e2140/content/ed/rules.yaml
@@ -17,6 +17,11 @@ World:
 	Voiced:
 		VoiceSet: EdVehicleVoice
 
+^EdAircraft:
+	Inherits: ^CoreAircraft
+	Voiced:
+		VoiceSet: EdVehicleVoice
+
 ed_colorpicker:
 	Inherits: ed_vehicles_st01b
 	RenderSprites:

--- a/mods/e2140/content/ed/vehicles/st02/weapons.yaml
+++ b/mods/e2140/content/ed/vehicles/st02/weapons.yaml
@@ -3,7 +3,7 @@ ed_vehicles_st02:
 	Range: 4c896
 	MinRange: 0c512
 	Report: 5.smp
-	ValidTargets: Ground, Water
+	ValidTargets: Ground, Water, Air
 	Burst: 3
 	BurstDelays: 8
 	Projectile: Missile
@@ -17,22 +17,34 @@ ed_vehicles_st02:
 		TrailInterval: 0
 		TrailPalette:
 		Shadow: True
+		ShadowColor: 00000046
 		HorizontalRateOfTurn: 20
 		RangeLimit: 6c0
-	Warhead@Damage: SpreadDamage
+	Warhead@DamageGround: SpreadDamage
 		Spread: 128
 		Damage: 20
 		ValidTargets: Ground
-	Warhead@Effect: CreateEffect
+	Warhead@DamageAir: SpreadDamage
+		Spread: 128
+		Damage: 20
+		ValidTargets: Air
+	Warhead@EffectGround: CreateEffect
 		Image: projectile_rocket
 		Explosions: explode
 		ExplosionPalette:
 		ImpactSounds: 14.smp
 		ValidTargets: Ground
+		InvalidTargets: Vehicle, Structure, Air
+	Warhead@EffectActor: CreateEffect
+		Image: projectile_cannon
+		Explosions: explode, explode2
+		ExplosionPalette:
+		ImpactSounds: 15.smp
+		ValidTargets: Vehicle, Structure, Air
 	Warhead@EffectWater: CreateEffect
 		Image: water_splash
 		Explosions: idle
 		ExplosionPalette:
 		ImpactSounds: 20.smp, 21.smp
 		ValidTargets: Water
-		InvalidTargets: Vehicle, Structure
+		InvalidTargets: Vehicle, Structure, Air

--- a/mods/e2140/content/shared/sequences/projectiles.yaml
+++ b/mods/e2140/content/shared/sequences/projectiles.yaml
@@ -74,3 +74,9 @@ projectile_ion:
 		Filename: projectile_ion.vspr
 		Start: 4
 		Length: 5
+
+projectile_bomb:
+	Defaults:
+		Filename: projectile_bomb.vspr
+	idle:
+		Length: 2

--- a/mods/e2140/content/ucs/vehicles/bigmech/weapons.yaml
+++ b/mods/e2140/content/ucs/vehicles/bigmech/weapons.yaml
@@ -3,7 +3,7 @@ ucs_vehicles_big_mech:
 	Range: 5c896
 	MinRange: 0c512
 	Report: 5.smp
-	ValidTargets: Ground, Water
+	ValidTargets: Ground, Water, Air
 	Burst: 16
 	BurstDelays: 5
 	Projectile: Missile
@@ -17,22 +17,34 @@ ucs_vehicles_big_mech:
 		TrailInterval: 0
 		TrailPalette:
 		Shadow: True
+		ShadowColor: 00000046
 		HorizontalRateOfTurn: 20
 		RangeLimit: 8c0
-	Warhead@Damage: SpreadDamage
+	Warhead@DamageGround: SpreadDamage
 		Spread: 128
 		Damage: 30
 		ValidTargets: Ground
-	Warhead@Effect: CreateEffect
+	Warhead@DamageAir: SpreadDamage
+		Spread: 128
+		Damage: 30
+		ValidTargets: Air
+	Warhead@EffectGround: CreateEffect
 		Image: projectile_rocket
 		Explosions: explode
 		ExplosionPalette:
 		ImpactSounds: 14.smp
 		ValidTargets: Ground
+		InvalidTargets: Vehicle, Structure, Air
+	Warhead@EffectActor: CreateEffect
+		Image: projectile_cannon
+		Explosions: explode, explode2
+		ExplosionPalette:
+		ImpactSounds: 15.smp
+		ValidTargets: Vehicle, Structure, Air
 	Warhead@EffectWater: CreateEffect
 		Image: water_splash
 		Explosions: idle
 		ExplosionPalette:
 		ImpactSounds: 20.smp, 21.smp
 		ValidTargets: Water
-		InvalidTargets: Vehicle, Structure
+		InvalidTargets: Vehicle, Structure, Air

--- a/mods/e2140/content/ucs/vehicles/spider_ii/weapons.yaml
+++ b/mods/e2140/content/ucs/vehicles/spider_ii/weapons.yaml
@@ -3,7 +3,7 @@ ucs_vehicles_spider_ii:
 	Range: 6c896
 	MinRange: 0c512
 	Report: 4.smp
-	ValidTargets: Ground, Water
+	ValidTargets: Ground, Water, Air
 	Burst: 4
 	BurstDelays: 13
 	Projectile: Missile
@@ -17,28 +17,33 @@ ucs_vehicles_spider_ii:
 		TrailInterval: 0
 		TrailPalette:
 		Shadow: True
+		ShadowColor: 00000046
 		HorizontalRateOfTurn: 20
 		RangeLimit: 8c0
-	Warhead@Damage: SpreadDamage
+	Warhead@DamageGround: SpreadDamage
 		Spread: 128
 		Damage: 80
 		ValidTargets: Ground
+	Warhead@DamageAir: SpreadDamage
+		Spread: 128
+		Damage: 80
+		ValidTargets: Air
 	Warhead@Effect: CreateEffect
 		Image: projectile_heavy_rocket
 		Explosions: explode
 		ExplosionPalette:
 		ImpactSounds: 14.smp
-		ValidTargets: Ground
+		ValidTargets: Ground, Air
 	Warhead@EffectRubble: CreateEffect
 		Image: rubble_big
 		Explosions: idle
 		ExplosionPalette:
 		ValidTargets: Ground
-		InvalidTargets: Vehicle, Structure
+		InvalidTargets: Vehicle, Structure, Air
 	Warhead@EffectWater: CreateEffect
 		Image: water_splash
 		Explosions: idle
 		ExplosionPalette:
 		ImpactSounds: 20.smp, 21.smp
 		ValidTargets: Water
-		InvalidTargets: Vehicle, Structure
+		InvalidTargets: Vehicle, Structure, Air

--- a/mods/e2140/content/ucs/vehicles/tiger_assault/weapons.yaml
+++ b/mods/e2140/content/ucs/vehicles/tiger_assault/weapons.yaml
@@ -3,7 +3,7 @@ ucs_vehicles_tiger_assault:
 	Range: 5c896
 	MinRange: 0c512
 	Report: 5.smp
-	ValidTargets: Ground, Water
+	ValidTargets: Ground, Water, Air
 	Burst: 4
 	BurstDelays: 13
 	Projectile: Missile
@@ -17,22 +17,34 @@ ucs_vehicles_tiger_assault:
 		TrailInterval: 0
 		TrailPalette:
 		Shadow: True
+		ShadowColor: 00000046
 		HorizontalRateOfTurn: 20
 		RangeLimit: 6c0
-	Warhead@Damage: SpreadDamage
+	Warhead@DamageGround: SpreadDamage
 		Spread: 128
 		Damage: 15
 		ValidTargets: Ground
-	Warhead@Effect: CreateEffect
+	Warhead@DamageAir: SpreadDamage
+		Spread: 128
+		Damage: 15
+		ValidTargets: Air
+	Warhead@EffectGround: CreateEffect
 		Image: projectile_rocket
 		Explosions: explode
 		ExplosionPalette:
 		ImpactSounds: 14.smp
 		ValidTargets: Ground
+		InvalidTargets: Vehicle, Structure, Air
+	Warhead@EffectActor: CreateEffect
+		Image: projectile_cannon
+		Explosions: explode, explode2
+		ExplosionPalette:
+		ImpactSounds: 15.smp
+		ValidTargets: Vehicle, Structure, Air
 	Warhead@EffectWater: CreateEffect
 		Image: water_splash
 		Explosions: idle
 		ExplosionPalette:
 		ImpactSounds: 20.smp, 21.smp
 		ValidTargets: Water
-		InvalidTargets: Vehicle, Structure
+		InvalidTargets: Vehicle, Structure, Air

--- a/mods/e2140/maps/testmap_ed/map.yaml
+++ b/mods/e2140/maps/testmap_ed/map.yaml
@@ -122,87 +122,105 @@ Actors:
 	Actor32: shared_buildings_power_plant
 		Owner: ED_Player
 		Location: 22,3
-		Health: 31
-	Actor33: ed_vehicles_mt201l
-		Owner: ED_Player
-		Location: 26,8
-		TurretFacing: 0
-		Facing: 384
-	Actor34: ed_vehicles_mt201l
+	Actor26: ed_vehicles_st01b
 		Owner: ED_Player
 		Facing: 384
-		Location: 27,8
-	Actor35: ed_vehicles_mt201l
-		Owner: ED_Player
-		Facing: 384
-		Location: 26,7
-	Actor36: ed_vehicles_mt201l
-		Owner: ED_Player
-		Facing: 384
-		Location: 27,7
-	Actor37: ed_vehicles_st02
-		Owner: ED_Player
-		Facing: 384
-		Location: 24,7
-	Actor38: ed_vehicles_st02
-		Owner: ED_Player
-		Facing: 384
-		Location: 23,7
-	Actor39: ed_vehicles_st02
-		Owner: ED_Player
-		Facing: 384
-		Location: 23,8
-	Actor40: ed_vehicles_st02
-		Owner: ED_Player
-		Facing: 384
-		Location: 24,8
-	Actor41: ed_vehicles_mt200
-		Owner: ED_Player
-		Facing: 384
-		Location: 21,7
-	Actor42: ed_vehicles_mt200
+		Location: 19,7
+	Actor27: ed_vehicles_st02
 		Owner: ED_Player
 		Facing: 384
 		Location: 20,7
-	Actor43: ed_vehicles_mt200
+	Actor33: ed_vehicles_mt200
 		Owner: ED_Player
 		Facing: 384
-		Location: 20,8
-	Actor44: ed_vehicles_mt200
+		Location: 21,7
+	Actor34: ed_vehicles_mt201l
 		Owner: ED_Player
 		Facing: 384
-		Location: 21,8
-	Actor45: ed_vehicles_st01b
+		Location: 22,7
+	Actor35: ed_vehicles_btti
 		Owner: ED_Player
 		Facing: 384
-		Location: 18,7
-	Actor46: ed_vehicles_st01b
+		Location: 23,7
+	Actor36: ed_vehicles_ht33r
 		Owner: ED_Player
 		Facing: 384
-		Location: 17,7
-	Actor47: ed_vehicles_st01b
+		Location: 24,7
+	Actor37: ed_vehicles_ht34j
 		Owner: ED_Player
 		Facing: 384
-		Location: 17,8
-	Actor48: ed_vehicles_st01b
+		Location: 25,7
+	Actor38: ed_vehicles_warhammer
 		Owner: ED_Player
 		Facing: 384
-		Location: 18,8
-	Actor49: ed_vehicles_btti
+		Location: 26,7
+	Actor39: ed_vehicles_screamer
 		Owner: ED_Player
 		Facing: 384
-		Location: 23,10
-	Actor50: ed_vehicles_btti
+		Location: 27,7
+	Actor40: ed_aircrafts_storm
 		Owner: ED_Player
 		Facing: 384
-		Location: 24,10
-	Actor51: ed_vehicles_btti
+		Location: 19,9
+	Actor41: ed_aircrafts_thunder
 		Owner: ED_Player
 		Facing: 384
-		Location: 23,11
-	Actor52: ed_vehicles_btti
+		Location: 21,9
+	Actor42: ed_aircrafts_hat
 		Owner: ED_Player
 		Facing: 384
-		Location: 24,11
+		Location: 23,9
+	Actor43: ed_aircrafts_vtol
+		Owner: ED_Player
+		Facing: 384
+		Location: 25,9
+	Actor44: ed_aircrafts_nemezis
+		Owner: ED_Player
+		Facing: 384
+		Location: 27,9
+	Actor45: ucs_vehicles_big_mech
+		Owner: UCS_AI
+		Facing: 384
+		Location: 9,23
+	Actor46: ucs_vehicles_big_mech
+		Owner: UCS_AI
+		Location: 3,21
+		Facing: 880
+	Actor47: ucs_vehicles_spider_ii
+		Owner: UCS_AI
+		Facing: 384
+		Location: 4,25
+	Actor48: ucs_vehicles_spider_ii
+		Owner: UCS_AI
+		Facing: 384
+		Location: 3,23
+	Actor49: ucs_vehicles_spider
+		Owner: UCS_AI
+		Location: 6,25
+		Facing: 578
+	Actor50: ucs_vehicles_raptor_ad
+		Owner: UCS_AI
+		Facing: 384
+		Location: 6,18
+	Actor51: ucs_vehicles_raptor_ad
+		Owner: UCS_AI
+		Location: 3,19
+		Facing: 769
+	Actor52: ucs_vehicles_raptor_ad
+		Owner: UCS_AI
+		Location: 7,20
+		Facing: 134
+	Actor53: ucs_vehicles_t100
+		Owner: UCS_AI
+		Location: 9,21
+		Facing: 586
+	Actor54: ucs_vehicles_t100
+		Owner: UCS_AI
+		Facing: 384
+		Location: 7,19
+	Actor55: ucs_vehicles_t100
+		Owner: UCS_AI
+		Location: 8,25
+		Facing: 384
 
 Rules: rules.yaml

--- a/mods/e2140/virtualassets/SPRM0.MIX.VirtualAssets.yaml
+++ b/mods/e2140/virtualassets/SPRM0.MIX.VirtualAssets.yaml
@@ -27,6 +27,9 @@ Generate:
 		explode: 8-15
 		explode2: 0-7
 
+	projectile_bomb:
+		idle: 60,61
+
 	smoke:
 		idle: 169-176
 


### PR DESCRIPTION
- Added all ED aircrafts
- Added default rules for aircraft husks.
- Adjusted shadow color for projectiles.
- Missile type actors can now target aircrafts. Rules were updated, so if a projectile hits air unit, it will damage only air unit. Otherwise it could have damage the air one and actor beneath it.
- Updated effects for some projectiles (it's different when they hit actors, just like it is in vanilla).
- Made extra sure that some effects will not be triggered when air actor is hit.
- Added missing cursors.
- Power plant explosion was renamed to `nuclear_explosion` as a few entities use that effect. This way it's more universal.

Some missing stuff:
- Aircrafts use vehicles production tab.
- No full implementation for cargo for HAT as there's no infantry to test it with.
- Palette for fast rotor is wrong.
- Nemezis/Heavy Bomber acts not correctly when it's targeting. It should be strafing longer, but it uses weapon's range for that. I might be missing something or `Gravity Bomb` wasn't made for that.
- Weapon stats for Nemezis are based on brief in game observations. Reload time needs further testing.
- THUNDER's reload time is a pure guess. Needs further testing.
- Slow rotor should have own `WithShadow` with different offset. Slow rotor's shadow should be rendered above main body.
- No moving sound. `WithMoveSound` trait was made for `Mobile` trait, not `Aircraft` trait. Besides, I believe it also needs to be conditional, as there two helicopter sounds: 29.smp and 30.smp. It appears only 29.smp is used in the game, but I think it would be better if 29.smp is used for slow rotor and 30.smp for fast rotor. For that a trait needs to be conditional.