### PR TITLE
Adjusted body `TurnSpeed` for actors + fixes.

### DIFF
--- a/mods/e2140/content/core/rules/defaults.yaml
+++ b/mods/e2140/content/core/rules/defaults.yaml
@@ -243,6 +243,7 @@
 		Type: vehicle
 	# Vehicles can kill infantry by moving over them and set movement modifiers.
 	Mobile:
+		TurnSpeed: 50
 		Locomotor: vehicle
 		BlockedCursor: generic-blocked
 	# Actor can be targeted by anything which attacks ground.

--- a/mods/e2140/content/ed/vehicles/btti/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/btti/rules.yaml
@@ -15,7 +15,6 @@ ed_vehicles_btti:
 		HP: 150
 	Mobile:
 		Speed: 100
-		TurnSpeed: 50
 	RevealsShroud:
 		Range: 3c896
 	Armament@PRIMARY:

--- a/mods/e2140/content/ed/vehicles/ht33r/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/ht33r/rules.yaml
@@ -15,7 +15,6 @@ ed_vehicles_ht33r:
 		HP: 600
 	Mobile:
 		Speed: 50
-		TurnSpeed: 50
 	RevealsShroud:
 		Range: 6c896
 	Turreted:

--- a/mods/e2140/content/ed/vehicles/ht34j/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/ht34j/rules.yaml
@@ -15,7 +15,6 @@ ed_vehicles_ht34j:
 		HP: 600
 	Mobile:
 		Speed: 50
-		TurnSpeed: 50
 	RevealsShroud:
 		Range: 4c896
 	Turreted:

--- a/mods/e2140/content/ed/vehicles/mt200/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/mt200/rules.yaml
@@ -15,7 +15,6 @@ ed_vehicles_mt200:
 		HP: 300
 	Mobile:
 		Speed: 90
-		TurnSpeed: 50
 	RevealsShroud:
 		Range: 5c896
 	Turreted:

--- a/mods/e2140/content/ed/vehicles/mt201l/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/mt201l/rules.yaml
@@ -15,7 +15,6 @@ ed_vehicles_mt201l:
 		HP: 300
 	Mobile:
 		Speed: 90
-		TurnSpeed: 50
 	RevealsShroud:
 		Range: 3c896
 	Turreted:

--- a/mods/e2140/content/ed/vehicles/screamer/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/screamer/rules.yaml
@@ -14,7 +14,6 @@ ed_vehicles_screamer:
 		HP: 300
 	Mobile:
 		Speed: 90
-		TurnSpeed: 50
 	RevealsShroud:
 		Range: 4c896
 	WithIdleOverlay:

--- a/mods/e2140/content/ed/vehicles/st01b/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/st01b/rules.yaml
@@ -15,7 +15,6 @@ ed_vehicles_st01b:
 		HP: 200
 	Mobile:
 		Speed: 90
-		TurnSpeed: 50
 	RevealsShroud:
 		Range: 3c896
 	Turreted:

--- a/mods/e2140/content/ed/vehicles/st02/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/st02/rules.yaml
@@ -15,7 +15,6 @@ ed_vehicles_st02:
 		HP: 200
 	Mobile:
 		Speed: 90
-		TurnSpeed: 50
 	RevealsShroud:
 		Range: 4c896
 	Turreted:

--- a/mods/e2140/content/ed/vehicles/warhammer/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/warhammer/rules.yaml
@@ -15,7 +15,6 @@ ed_vehicles_warhammer:
 		HP: 600
 	Mobile:
 		Speed: 50
-		TurnSpeed: 50
 	RevealsShroud:
 		Range: 5c896
 	Turreted:

--- a/mods/e2140/content/shared/vehicles/hcrm/rules.yaml
+++ b/mods/e2140/content/shared/vehicles/hcrm/rules.yaml
@@ -20,7 +20,6 @@ shared_vehicles_hcrm:
 		HP: 200
 	Mobile:
 		Speed: 91
-		TurnSpeed: 50
 	RevealsShroud:
 		Range: 2c896
 	Turreted:

--- a/mods/e2140/content/ucs/rules.yaml
+++ b/mods/e2140/content/ucs/rules.yaml
@@ -41,6 +41,8 @@ World:
 	Mobile:
 		Locomotor: vehicleFastSand
 		AlwaysTurnInPlace: true
+	Mobile:
+		TurnSpeed: 32
 
 ucs_colorpicker:
 	Inherits: ucs_vehicles_tiger_assault

--- a/mods/e2140/content/ucs/vehicles/bigmech/rules.yaml
+++ b/mods/e2140/content/ucs/vehicles/bigmech/rules.yaml
@@ -15,7 +15,6 @@ ucs_vehicles_big_mech:
 		HP: 800
 	Mobile:
 		Speed: 68
-		TurnSpeed: 32
 	RevealsShroud:
 		Range: 5c896
 	Armament@PRIMARY:

--- a/mods/e2140/content/ucs/vehicles/raptor_ad/rules.yaml
+++ b/mods/e2140/content/ucs/vehicles/raptor_ad/rules.yaml
@@ -15,7 +15,6 @@ ucs_vehicles_raptor_ad:
 		HP: 200
 	Mobile:
 		Speed: 68
-		TurnSpeed: 32
 	RevealsShroud:
 		Range: 4c896
 	WithFacingSpriteBody@shadow:

--- a/mods/e2140/content/ucs/vehicles/raptor_es/rules.yaml
+++ b/mods/e2140/content/ucs/vehicles/raptor_es/rules.yaml
@@ -15,7 +15,6 @@ ucs_vehicles_raptor_es:
 		HP: 200
 	Mobile:
 		Speed: 68
-		TurnSpeed: 32
 	RevealsShroud:
 		Range: 3c896
 	WithFacingSpriteBody@shadow:

--- a/mods/e2140/content/ucs/vehicles/shadow/rules.yaml
+++ b/mods/e2140/content/ucs/vehicles/shadow/rules.yaml
@@ -13,8 +13,7 @@ ucs_vehicles_shadow:
 	Health:
 		HP: 200
 	Mobile:
-		Speed: 91
-		TurnSpeed: 50
+		Speed: 90
 	RevealsShroud:
 		Range: 4c896
 	ProximityExternalCondition:

--- a/mods/e2140/content/ucs/vehicles/spider/rules.yaml
+++ b/mods/e2140/content/ucs/vehicles/spider/rules.yaml
@@ -14,7 +14,6 @@ ucs_vehicles_spider:
 		HP: 300
 	Mobile:
 		Speed: 50
-		TurnSpeed: 30
 	RevealsShroud:
 		Range: 4c896
 	Turreted:

--- a/mods/e2140/content/ucs/vehicles/t100/rules.yaml
+++ b/mods/e2140/content/ucs/vehicles/t100/rules.yaml
@@ -15,7 +15,6 @@ ucs_vehicles_t100:
 		HP: 80
 	Mobile:
 		Speed: 50
-		TurnSpeed: 50
 	RevealsShroud:
 		Range: 2c896
 	Turreted:

--- a/mods/e2140/content/ucs/vehicles/tiger_assault/rules.yaml
+++ b/mods/e2140/content/ucs/vehicles/tiger_assault/rules.yaml
@@ -14,7 +14,6 @@ ucs_vehicles_tiger_assault:
 		HP: 400
 	Mobile:
 		Speed: 50
-		TurnSpeed: 30
 	RevealsShroud:
 		Range: 5c896
 	Turreted:

--- a/mods/e2140/content/ucs/vehicles/wtp_100/rules.yaml
+++ b/mods/e2140/content/ucs/vehicles/wtp_100/rules.yaml
@@ -13,9 +13,8 @@ ucs_vehicles_wtp_100:
 	Health:
 		HP: 300
 	Mobile:
-		Speed: 68
-		TurnSpeed: 32
+		Speed: 90
 	RevealsShroud:
-		Range: 5c896
+		Range: 2c896
 	# WTP 100 doesn't have move animation.
 	-WithMoveAnimation:


### PR DESCRIPTION
All vehicles have the same body turn speed. Only walkers have different value. So I decided to make it more global.

- Default body `TurnSpeed` 50 for vehicles.
- Default body `TurnSpeed` 32 for mechs.
- SHADOW's speed was meant to be 90, not 91.
- Fixed wrong speed and reveal shroud values for WTP 100.