### PR TITLE
Adjusted missiles' accuracy vs aircrafts + cleanup.

### DIFF
--- a/mods/e2140/content/core/rules/defaults.yaml
+++ b/mods/e2140/content/core/rules/defaults.yaml
@@ -69,6 +69,8 @@
 	# Play sound notification on destruction
 	ActorLostNotification:
 		TextNotification: Unit lost.
+	# Unit is added to the observer stats.
+	UpdatesPlayerStatistics:
 
 # Base for all buildings and towers.
 ^CoreConstruction:
@@ -344,7 +346,7 @@
 	# Husks shouldn't be selectable, only interctable.
 	-Selectable:
 	Interactable:
-	# Default health for aircraft husks
+	# Default health for aircraft husks.
 	Health:
 		HP: 1000
 	# Aircraft husks fall to the ground and explode.
@@ -353,6 +355,10 @@
 	# Aircraft husks are no longer targetable.
 	Targetable@Airborne:
 		TargetTypes: NoTarget
+	# Do not notify the player that a husk was lost.
+	-ActorLostNotification:
+	# Husks are not counted towards player's army.
+	-UpdatesPlayerStatistics:
 
 # Special light vehicles
 ^CoreLightVehicle:

--- a/mods/e2140/content/core/rules/player.yaml
+++ b/mods/e2140/content/core/rules/player.yaml
@@ -46,6 +46,8 @@ Player:
 	TechTree:
 	# Render terrain on Radar widget (minimap).
 	PlayerRadarTerrain:
+	# Collects observer stats.
+	PlayerStatistics:
 
 # Map editor specific player setup.
 EditorPlayer:

--- a/mods/e2140/content/ed/aircrafts/thunder/weapons.yaml
+++ b/mods/e2140/content/ed/aircrafts/thunder/weapons.yaml
@@ -19,7 +19,6 @@ ed_aircrafts_thunder:
 		Shadow: True
 		ShadowColor: 00000046
 		HorizontalRateOfTurn: 20
-		RangeLimit: 6c0
 	Warhead@Damage: SpreadDamage
 		Spread: 128
 		Damage: 20

--- a/mods/e2140/content/ed/aircrafts/vtol/weapons.yaml
+++ b/mods/e2140/content/ed/aircrafts/vtol/weapons.yaml
@@ -19,7 +19,6 @@ ed_aircrafts_vtol:
 		Shadow: True
 		ShadowColor: 00000046
 		HorizontalRateOfTurn: 20
-		RangeLimit: 8c0
 	Warhead@Damage: SpreadDamage
 		Spread: 128
 		Damage: 80

--- a/mods/e2140/content/ed/vehicles/ht33r/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/ht33r/rules.yaml
@@ -25,5 +25,10 @@ ed_vehicles_ht33r:
 		Recoil: 80
 		RecoilRecovery: 38
 		LocalOffset: 200,100,100,200,-100,100,200,0,100
-		LocalYaw: 0, 0
+		MuzzlePalette:
+	Armament@SECONDARY:
+		Weapon: ed_vehicles_ht33r_air
+		Recoil: 80
+		RecoilRecovery: 38
+		LocalOffset: 200,100,100,200,-100,100,200,0,100
 		MuzzlePalette:

--- a/mods/e2140/content/ed/vehicles/ht33r/weapons.yaml
+++ b/mods/e2140/content/ed/vehicles/ht33r/weapons.yaml
@@ -3,7 +3,7 @@ ed_vehicles_ht33r:
 	Range: 6c896
 	MinRange: 0c512
 	Report: 4.smp
-	ValidTargets: Ground, Water, Air
+	ValidTargets: Ground, Water
 	Burst: 3
 	BurstDelays: 24
 	Projectile: Missile
@@ -19,7 +19,6 @@ ed_vehicles_ht33r:
 		Shadow: True
 		ShadowColor: 00000046
 		HorizontalRateOfTurn: 20
-		RangeLimit: 8c0
 	Warhead@DamageGround: SpreadDamage
 		Spread: 128
 		Damage: 80
@@ -47,3 +46,9 @@ ed_vehicles_ht33r:
 		ImpactSounds: 20.smp, 21.smp
 		ValidTargets: Water
 		InvalidTargets: Vehicle, Structure, Air
+
+ed_vehicles_ht33r_air:
+	Inherits: ed_vehicles_ht33r
+	ValidTargets: Air
+	Projectile: Missile
+		Inaccuracy: 2c0

--- a/mods/e2140/content/ed/vehicles/st02/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/st02/rules.yaml
@@ -25,5 +25,10 @@ ed_vehicles_st02:
 		Recoil: 80
 		RecoilRecovery: 38
 		LocalOffset: 100,-100,0, 100,100,0
-		LocalYaw: 0, 0
+		MuzzlePalette:
+	Armament@SECONDARY:
+		Weapon: ed_vehicles_st02_air
+		Recoil: 80
+		RecoilRecovery: 38
+		LocalOffset: 100,-100,0, 100,100,0
 		MuzzlePalette:

--- a/mods/e2140/content/ed/vehicles/st02/weapons.yaml
+++ b/mods/e2140/content/ed/vehicles/st02/weapons.yaml
@@ -3,7 +3,7 @@ ed_vehicles_st02:
 	Range: 4c896
 	MinRange: 0c512
 	Report: 5.smp
-	ValidTargets: Ground, Water, Air
+	ValidTargets: Ground, Water
 	Burst: 3
 	BurstDelays: 8
 	Projectile: Missile
@@ -19,7 +19,6 @@ ed_vehicles_st02:
 		Shadow: True
 		ShadowColor: 00000046
 		HorizontalRateOfTurn: 20
-		RangeLimit: 6c0
 	Warhead@DamageGround: SpreadDamage
 		Spread: 128
 		Damage: 20
@@ -48,3 +47,9 @@ ed_vehicles_st02:
 		ImpactSounds: 20.smp, 21.smp
 		ValidTargets: Water
 		InvalidTargets: Vehicle, Structure, Air
+
+ed_vehicles_st02_air:
+	Inherits: ed_vehicles_st02
+	ValidTargets: Air
+	Projectile: Missile
+		Inaccuracy: 2c0

--- a/mods/e2140/content/ucs/vehicles/bigmech/rules.yaml
+++ b/mods/e2140/content/ucs/vehicles/bigmech/rules.yaml
@@ -20,13 +20,16 @@ ucs_vehicles_big_mech:
 		Range: 5c896
 	Armament@PRIMARY:
 		Weapon: ucs_vehicles_big_mech
-		Recoil: 0
-		RecoilRecovery: 0
 		LocalOffset: 200,-425,0, 200,425,0
-		LocalYaw: 0, 0
+		MuzzlePalette:
+	Armament@SECONDARY:
+		Weapon: ucs_vehicles_big_mech_air
+		LocalOffset: 200,-425,0, 200,425,0
 		MuzzlePalette:
 	WithMoveSound:
 		Sound: 32.smp
 	WithMoveAnimation@turn:
 		ValidMovementTypes: Turn
 		MoveSequence: move.turn
+	AttackFrontal:
+		FacingTolerance: 25

--- a/mods/e2140/content/ucs/vehicles/bigmech/weapons.yaml
+++ b/mods/e2140/content/ucs/vehicles/bigmech/weapons.yaml
@@ -3,7 +3,7 @@ ucs_vehicles_big_mech:
 	Range: 5c896
 	MinRange: 0c512
 	Report: 5.smp
-	ValidTargets: Ground, Water, Air
+	ValidTargets: Ground, Water
 	Burst: 16
 	BurstDelays: 5
 	Projectile: Missile
@@ -19,7 +19,6 @@ ucs_vehicles_big_mech:
 		Shadow: True
 		ShadowColor: 00000046
 		HorizontalRateOfTurn: 20
-		RangeLimit: 8c0
 	Warhead@DamageGround: SpreadDamage
 		Spread: 128
 		Damage: 30
@@ -48,3 +47,9 @@ ucs_vehicles_big_mech:
 		ImpactSounds: 20.smp, 21.smp
 		ValidTargets: Water
 		InvalidTargets: Vehicle, Structure, Air
+
+ucs_vehicles_big_mech_air:
+	Inherits: ucs_vehicles_big_mech
+	ValidTargets: Air
+	Projectile: Missile
+		Inaccuracy: 2c0

--- a/mods/e2140/content/ucs/vehicles/raptor_ad/rules.yaml
+++ b/mods/e2140/content/ucs/vehicles/raptor_ad/rules.yaml
@@ -24,10 +24,12 @@ ucs_vehicles_raptor_ad:
 		# RequiresCondition: !cloaked
 	Armament@PRIMARY:
 		Weapon: ucs_vehicles_raptor_ad
-		Recoil: 0
-		RecoilRecovery: 0
 		LocalOffset: 100,-200,0, 100,200,0
-		LocalYaw: 0, 0
+		MuzzlePalette:
+		PauseOnCondition: !ammo
+	Armament@SECONDARY:
+		Weapon: ucs_vehicles_raptor_ad_air
+		LocalOffset: 100,-200,0, 100,200,0
 		MuzzlePalette:
 		PauseOnCondition: !ammo
 	WithMoveSound:
@@ -42,3 +44,5 @@ ucs_vehicles_raptor_ad:
 		Delay: 62
 		ResetOnFire: True
 		Count: 1
+	AttackFrontal:
+		FacingTolerance: 25

--- a/mods/e2140/content/ucs/vehicles/raptor_ad/weapons.yaml
+++ b/mods/e2140/content/ucs/vehicles/raptor_ad/weapons.yaml
@@ -3,7 +3,7 @@ ucs_vehicles_raptor_ad:
 	Range: 4c896
 	MinRange: 0c512
 	Report: 5.smp
-	ValidTargets: Ground, Water, Air
+	ValidTargets: Ground, Water
 	Burst: 2
 	BurstDelays: 12
 	Projectile: Missile
@@ -19,7 +19,6 @@ ucs_vehicles_raptor_ad:
 		Shadow: True
 		ShadowColor: 00000046
 		HorizontalRateOfTurn: 20
-		RangeLimit: 6c0
 	Warhead@DamageGround: SpreadDamage
 		Spread: 128
 		Damage: 25
@@ -48,3 +47,9 @@ ucs_vehicles_raptor_ad:
 		ImpactSounds: 20.smp, 21.smp
 		ValidTargets: Water
 		InvalidTargets: Vehicle, Structure, Air
+
+ucs_vehicles_raptor_ad_air:
+	Inherits: ucs_vehicles_raptor_ad
+	ValidTargets: Air
+	Projectile: Missile
+		Inaccuracy: 2c0

--- a/mods/e2140/content/ucs/vehicles/spider_ii/rules.yaml
+++ b/mods/e2140/content/ucs/vehicles/spider_ii/rules.yaml
@@ -19,8 +19,16 @@ ucs_vehicles_spider_ii:
 	Turreted:
 		TurnSpeed: 30
 		Offset: 0,0,300
-	Armament:
+	Armament@PRIMARY:
 		Weapon: ucs_vehicles_spider_ii
+		Recoil: 64
+		RecoilRecovery: 38
+		LocalOffset: 300,-300,0, 300,300,0
+		LocalYaw: 0, 0
+		MuzzlePalette:
+		PauseOnCondition: !ammo
+	Armament@SECONDARY:
+		Weapon: ucs_vehicles_spider_ii_air
 		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 300,-300,0, 300,300,0

--- a/mods/e2140/content/ucs/vehicles/spider_ii/weapons.yaml
+++ b/mods/e2140/content/ucs/vehicles/spider_ii/weapons.yaml
@@ -3,7 +3,7 @@ ucs_vehicles_spider_ii:
 	Range: 6c896
 	MinRange: 0c512
 	Report: 4.smp
-	ValidTargets: Ground, Water, Air
+	ValidTargets: Ground, Water
 	Burst: 4
 	BurstDelays: 13
 	Projectile: Missile
@@ -19,7 +19,6 @@ ucs_vehicles_spider_ii:
 		Shadow: True
 		ShadowColor: 00000046
 		HorizontalRateOfTurn: 20
-		RangeLimit: 8c0
 	Warhead@DamageGround: SpreadDamage
 		Spread: 128
 		Damage: 80
@@ -47,3 +46,9 @@ ucs_vehicles_spider_ii:
 		ImpactSounds: 20.smp, 21.smp
 		ValidTargets: Water
 		InvalidTargets: Vehicle, Structure, Air
+
+ucs_vehicles_spider_ii_air:
+	Inherits: ucs_vehicles_spider_ii
+	ValidTargets: Air
+	Projectile: Missile
+		Inaccuracy: 2c0

--- a/mods/e2140/content/ucs/vehicles/tiger_assault/rules.yaml
+++ b/mods/e2140/content/ucs/vehicles/tiger_assault/rules.yaml
@@ -24,7 +24,6 @@ ucs_vehicles_tiger_assault:
 		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 300,-300,-100
-		LocalYaw: 0, 0
 		MuzzlePalette:
 		PauseOnCondition: !ammo
 	Armament@SECONDARY:
@@ -32,7 +31,20 @@ ucs_vehicles_tiger_assault:
 		Recoil: 64
 		RecoilRecovery: 38
 		LocalOffset: 300,300,-100
-		LocalYaw: 0, 0
+		MuzzlePalette:
+		PauseOnCondition: !ammo
+	Armament@TERTIARY:
+		Weapon: ucs_vehicles_tiger_assault_air
+		Recoil: 64
+		RecoilRecovery: 38
+		LocalOffset: 300,-300,-100
+		MuzzlePalette:
+		PauseOnCondition: !ammo
+	Armament@QUATERNARY:
+		Weapon: ucs_vehicles_tiger_assault_air
+		Recoil: 64
+		RecoilRecovery: 38
+		LocalOffset: 300,300,-100
 		MuzzlePalette:
 		PauseOnCondition: !ammo
 	WithMoveSound:

--- a/mods/e2140/content/ucs/vehicles/tiger_assault/weapons.yaml
+++ b/mods/e2140/content/ucs/vehicles/tiger_assault/weapons.yaml
@@ -19,7 +19,6 @@ ucs_vehicles_tiger_assault:
 		Shadow: True
 		ShadowColor: 00000046
 		HorizontalRateOfTurn: 20
-		RangeLimit: 6c0
 	Warhead@DamageGround: SpreadDamage
 		Spread: 128
 		Damage: 15
@@ -48,3 +47,9 @@ ucs_vehicles_tiger_assault:
 		ImpactSounds: 20.smp, 21.smp
 		ValidTargets: Water
 		InvalidTargets: Vehicle, Structure, Air
+
+ucs_vehicles_tiger_assault_air:
+	Inherits: ucs_vehicles_tiger_assault
+	ValidTargets: Air
+	Projectile: Missile
+		Inaccuracy: 2c0


### PR DESCRIPTION
- Accuracy against aircrafts was reduced.
- Aircraft husks are no longer counted towards player's army.
- Unit lost notification won't be played if an aircraft husk is lost.
- Added missing traits for player statistics.
- Removed unused yaml code from armaments.
- Removed `RangeLimit` from missiles. It will default to weapon's range.
- Increased `FacingTolerance` for RAPTOR AD and Big Mech. They were kinda twitching when they were targeting moving targets, especially air ones. 