### PR TITLE
Added Air Base

### DIFF
--- a/mods/e2140/chrome/layouts/ingame-player.yaml
+++ b/mods/e2140/chrome/layouts/ingame-player.yaml
@@ -507,22 +507,22 @@ Container@PLAYER_WIDGETS:
 									X: 3
 									Y: 3
 									ImageCollection: production-icons
-						#ProductionTypeButton@Aircraft:
-						#	Logic: AddFactionSuffixLogic
-						#	X: 116
-						#	Width: 23
-						#	Height: 21
-						#	Background: sidebar-button
-						#	TooltipText: Aircraft
-						#	TooltipContainer: TOOLTIP_CONTAINER
-						#	ProductionGroup: Aircraft
-						#	Key: ProductionTypeAircraft
-						#	Children:
-						#		Image@ICON:
-						#			Logic: AddFactionSuffixLogic
-						#			X: 3
-						#			Y: 3
-						#			ImageCollection: production-icons
+						ProductionTypeButton@Aircraft:
+							Logic: AddFactionSuffixLogic
+							X: 116
+							Width: 23
+							Height: 21
+							Background: sidebar-production-tab
+							TooltipText: Aircraft
+							TooltipContainer: TOOLTIP_CONTAINER
+							ProductionGroup: Aircraft
+							Key: ProductionTypeAircraft
+							Children:
+								Image@ICON:
+									Logic: AddFactionSuffixLogic
+									X: 3
+									Y: 3
+									ImageCollection: production-icons
 						#ProductionTypeButton@Naval:
 						#	Logic: AddFactionSuffixLogic
 						#	X: 145

--- a/mods/e2140/content/ed/aircrafts/hat/rules.yaml
+++ b/mods/e2140/content/ed/aircrafts/hat/rules.yaml
@@ -6,7 +6,7 @@ ed_aircrafts_hat:
 		Cost: 1000
 	Buildable:
 		IconPalette:
-		Queue: Vehicle.ED
+		Queue: Aircraft.ED
 		BuildDuration: 60
 	Selectable:
 		Bounds: 1184, 1072, 0, 0

--- a/mods/e2140/content/ed/aircrafts/nemezis/rules.yaml
+++ b/mods/e2140/content/ed/aircrafts/nemezis/rules.yaml
@@ -7,7 +7,7 @@ ed_aircrafts_nemezis:
 		Cost: 2300
 	Buildable:
 		IconPalette:
-		Queue: Vehicle.ED
+		Queue: Aircraft.ED
 		BuildDuration: 60
 	Selectable:
 		Bounds: 1680, 1648, 0, 0

--- a/mods/e2140/content/ed/aircrafts/storm/rules.yaml
+++ b/mods/e2140/content/ed/aircrafts/storm/rules.yaml
@@ -7,7 +7,7 @@ ed_aircrafts_storm:
 		Cost: 500
 	Buildable:
 		IconPalette:
-		Queue: Vehicle.ED
+		Queue: Aircraft.ED
 		BuildDuration: 60
 	Selectable:
 		Bounds: 1312, 928, 0, 0

--- a/mods/e2140/content/ed/aircrafts/thunder/rules.yaml
+++ b/mods/e2140/content/ed/aircrafts/thunder/rules.yaml
@@ -7,7 +7,7 @@ ed_aircrafts_thunder:
 		Cost: 700
 	Buildable:
 		IconPalette:
-		Queue: Vehicle.ED
+		Queue: Aircraft.ED
 		BuildDuration: 60
 	Selectable:
 		Bounds: 1312, 928, 0, 0

--- a/mods/e2140/content/ed/aircrafts/vtol/rules.yaml
+++ b/mods/e2140/content/ed/aircrafts/vtol/rules.yaml
@@ -7,7 +7,7 @@ ed_aircrafts_vtol:
 		Cost: 900
 	Buildable:
 		IconPalette:
-		Queue: Vehicle.ED
+		Queue: Aircraft.ED
 		BuildDuration: 60
 	Selectable:
 		Bounds: 992, 848, 0, 0

--- a/mods/e2140/content/shared/buildings/air_base/rules.yaml
+++ b/mods/e2140/content/shared/buildings/air_base/rules.yaml
@@ -1,0 +1,109 @@
+shared_buildings_air_base:
+	Inherits: ^CoreBuilding
+	Tooltip:
+		Name: Air Base
+	Health:
+		HP: 500
+	Building:
+		Dimensions: 4,3
+		Footprint: =xxx xxx= ====
+	HitShape:
+		TargetableOffsets: 512,-412,0,   512,412,0,   1524,-412,0,   1524,412,0
+		Type: Rectangle
+			TopLeft: -1024, -1524
+			BottomRight: 1024, 524
+	Selectable:
+		Bounds: 2064, 1984, 0,-432
+	Power:
+		Amount: -200
+	Production:
+		Produces: Aircraft.ED, Aircraft.UCS
+		RequiresCondition: !Transforming
+	ProductionQueue@ED:
+		Type: Aircraft.ED
+		Factions: ed
+		Group: Aircraft
+		LowPowerModifier: 150
+		ReadyAudio: ProductionComplete
+		QueuedAudio: ProductionStarted
+		OnHoldAudio: ProductionInterrupted
+		CancelledAudio: ProductionCancelled
+	ProductionQueue@UCS:
+		Type: Aircraft.UCS
+		Factions: ucs
+		Group: Aircraft
+		LowPowerModifier: 150
+		ReadyAudio: ProductionComplete
+		QueuedAudio: ProductionStarted
+		OnHoldAudio: ProductionInterrupted
+		CancelledAudio: ProductionCancelled
+	ProductionBar@ED:
+		ProductionType: Aircraft.ED
+	ProductionBar@UCS:
+		ProductionType: Aircraft.UCS
+	ProvidesPrerequisite:
+	Exit@Exit1:
+		SpawnOffset: 1500, -900, 0
+		ExitCell: 4,0
+		Facing: 768
+	Exit@Exit2:
+		SpawnOffset: 1500, -900, 0
+		ExitCell: 4,-1
+		Facing: 896
+	Exit@Exit3:
+		SpawnOffset: 1500, -900, 0
+		ExitCell: 3,-1
+		Facing: 0
+	Exit@Exit4:
+		SpawnOffset: 1500, -900, 0
+		ExitCell: 4,1
+		Facing: 640
+	Exit@Exit5:
+		SpawnOffset: 1500, -900, 0
+		ExitCell: 3,1
+		Facing: 500
+	Exit@Exit6:
+		SpawnOffset: -1400, 0, 0
+		ExitCell: 0,0
+		Facing: 0
+	Exit@Exit7:
+		SpawnOffset: -1400, 0, 0
+		ExitCell: -1,0
+		Facing: 100
+	Exit@Exit8:
+		SpawnOffset: -1400, 0, 0
+		ExitCell: -1,1
+		Facing: 245
+	Exit@Exit9:
+		SpawnOffset: -1400, 0, 0
+		ExitCell: -1,2
+		Facing: 384
+	Exit@Exit10:
+		SpawnOffset: -1400, 0, 0
+		ExitCell: 0,2
+		Facing: 500
+	WithIdleOverlay@HelipadLeft:
+		Sequence: helipad-left
+		RequiresCondition: !Transforming
+	WithIdleOverlay@HelipadLeftLight:
+		Sequence: helipad-left-light
+		RequiresCondition: !Transforming
+	WithIdleOverlay@HelipadRight:
+		Sequence: helipad-right
+		RequiresCondition: !Transforming
+	WithIdleOverlay@HelipadRightLight:
+		Sequence: helipad-right-light
+		RequiresCondition: !Transforming
+
+shared_mcu_air_base:
+	Inherits@1: ^SharedVehicleMcu
+	Tooltip:
+		Name: Mobile Air Base
+	Transforms:
+		IntoActor: shared_buildings_air_base
+	Valued:
+		Cost: 1300
+	Buildable:
+		IconPalette:
+		Queue: Building.UCS, Building.ED
+		BuildDuration: 160

--- a/mods/e2140/content/shared/buildings/air_base/sequences.yaml
+++ b/mods/e2140/content/shared/buildings/air_base/sequences.yaml
@@ -1,0 +1,31 @@
+shared_buildings_air_base:
+	Defaults:
+		Filename: building_air_base.vspr
+		Offset: 1,-45,0
+		ZOffset: -1024
+	idle:
+	idle_light:
+		Start: 1
+	damaged-idle:
+		Start: 2
+	damaged-idle_light:
+		Start: 3
+	helipad-left:
+		Start: 4
+		Offset: -91, -4
+	helipad-left-light:
+		Start: 5
+		Offset: -91, -4
+	helipad-right:
+		Start: 6
+		Offset: 97, -58
+	helipad-right-light:
+		Start: 7
+		Offset: 97, -58
+
+shared_mcu_air_base:
+	Inherits: shared_mcu
+	# TODO remove this!!! We only need faction specific variants!
+	icon:
+		Filename: SPRI1.MIX
+		Start: 185

--- a/mods/e2140/content/shared/mod.yaml
+++ b/mods/e2140/content/shared/mod.yaml
@@ -5,6 +5,7 @@ Rules:
 	e2140|content/shared/buildings/power_plant/rules.yaml
 	e2140|content/shared/vehicles/mcu/rules.yaml
 	e2140|content/shared/vehicles/hcrm/rules.yaml
+	e2140|content/shared/buildings/air_base/rules.yaml
 
 Sequences:
 	e2140|content/shared/sequences/projectiles.yaml
@@ -12,6 +13,7 @@ Sequences:
 	e2140|content/shared/vehicles/mcu/sequences.yaml
 	e2140|content/shared/buildings/power_plant/sequences.yaml
 	e2140|content/shared/vehicles/hcrm/sequences.yaml
+	e2140|content/shared/buildings/air_base/sequences.yaml
 
 Weapons:
 	e2140|content/shared/vehicles/hcrm/weapons.yaml

--- a/mods/e2140/content/ucs/aircrafts/gargoil/rules.yaml
+++ b/mods/e2140/content/ucs/aircrafts/gargoil/rules.yaml
@@ -7,7 +7,7 @@ usc_aircrafts_gargoil:
 		Cost: 600
 	Buildable:
 		IconPalette:
-		Queue: Vehicle.UCS
+		Queue: Aircraft.UCS
 		BuildDuration: 60
 	Selectable:
 		Bounds: 960, 688, 0, 0

--- a/mods/e2140/content/ucs/aircrafts/gargoil2/rules.yaml
+++ b/mods/e2140/content/ucs/aircrafts/gargoil2/rules.yaml
@@ -7,7 +7,7 @@ ucs_aircrafts_gargoil_ii:
 		Cost: 900
 	Buildable:
 		IconPalette:
-		Queue: Vehicle.UCS
+		Queue: Aircraft.UCS
 		BuildDuration: 60
 	Selectable:
 		Bounds: 960, 688, 0, 0

--- a/mods/e2140/content/ucs/aircrafts/hell_wind/rules.yaml
+++ b/mods/e2140/content/ucs/aircrafts/hell_wind/rules.yaml
@@ -7,7 +7,7 @@ ucs_aircrafts_hell_wind:
 		Cost: 1000
 	Buildable:
 		IconPalette:
-		Queue: Vehicle.UCS
+		Queue: Aircraft.UCS
 		BuildDuration: 60
 	Selectable:
 		Bounds: 1280, 1056, 0, 0

--- a/mods/e2140/maps/testmap_ed/map.yaml
+++ b/mods/e2140/maps/testmap_ed/map.yaml
@@ -222,5 +222,8 @@ Actors:
 		Owner: UCS_AI
 		Location: 8,25
 		Facing: 384
+	Actor56: shared_buildings_air_base
+		Owner: ED_Player
+		Location: 3,3
 
 Rules: rules.yaml

--- a/mods/e2140/maps/testmap_ucs/map.yaml
+++ b/mods/e2140/maps/testmap_ucs/map.yaml
@@ -103,31 +103,6 @@ Actors:
 		Owner: UCS_AI
 		Location: 6,21
 		Facing: 768
-	Actor26: ucs_vehicles_tiger_assault
-		Owner: UCS_Player
-		Location: 20,11
-		Facing: 384
-	Actor27: ucs_vehicles_tiger_assault
-		Owner: UCS_Player
-		Facing: 384
-		Location: 21,11
-	Actor28: ucs_vehicles_raptor_es
-		Owner: UCS_Player
-		Facing: 384
-		Location: 24,10
-	Actor29: ucs_vehicles_raptor_es
-		Owner: UCS_Player
-		Facing: 384
-		Location: 23,10
-	Actor30: shared_buildings_power_plant
-		Owner: UCS_Player
-		Location: 28,2
-	Actor31: ucs_buildings_heavy_tech
-		Owner: UCS_Player
-		Location: 25,3
-	Actor32: ucs_buildings_prod_center
-		Owner: UCS_Player
-		Location: 21,2
 	Actor33: ucs_mcu_prod_center
 		Owner: UCS_Player
 		Facing: 384
@@ -140,5 +115,65 @@ Actors:
 		Owner: UCS_Player
 		Facing: 384
 		Location: 29,12
+	Actor36: shared_buildings_air_base
+		Owner: UCS_Player
+		Location: 3,3
+	Actor32: ucs_buildings_prod_center
+		Owner: UCS_Player
+		Location: 16,2
+	Actor30: shared_buildings_power_plant
+		Owner: UCS_Player
+		Location: 19,2
+	Actor31: ucs_buildings_heavy_tech
+		Owner: UCS_Player
+		Location: 23,3
+	Actor26: ucs_vehicles_t100
+		Owner: UCS_Player
+		Facing: 384
+		Location: 18,7
+	Actor27: ucs_vehicles_raptor_es
+		Owner: UCS_Player
+		Facing: 384
+		Location: 19,7
+	Actor28: ucs_vehicles_raptor_ad
+		Owner: UCS_Player
+		Facing: 384
+		Location: 20,7
+	Actor29: ucs_vehicles_tiger_assault
+		Owner: UCS_Player
+		Facing: 384
+		Location: 21,7
+	Actor37: ucs_vehicles_spider
+		Owner: UCS_Player
+		Facing: 384
+		Location: 22,7
+	Actor38: ucs_vehicles_spider_ii
+		Owner: UCS_Player
+		Facing: 384
+		Location: 23,7
+	Actor39: ucs_vehicles_big_mech
+		Owner: UCS_Player
+		Facing: 384
+		Location: 24,7
+	Actor40: ucs_vehicles_wtp_100
+		Owner: UCS_Player
+		Facing: 384
+		Location: 25,7
+	Actor41: ucs_vehicles_shadow
+		Owner: UCS_Player
+		Facing: 384
+		Location: 26,7
+	Actor42: usc_aircrafts_gargoil
+		Owner: UCS_Player
+		Facing: 384
+		Location: 18,9
+	Actor43: ucs_aircrafts_hell_wind
+		Owner: UCS_Player
+		Facing: 384
+		Location: 19,9
+	Actor44: ucs_aircrafts_gargoil_ii
+		Owner: UCS_Player
+		Facing: 384
+		Location: 20,9
 
 Rules: rules.yaml


### PR DESCRIPTION
- Added Air Base
- Moved aircraft actors to `Aircraft` production tab.
- Air Base can build aircrafts (temporary solution).
- Updated test maps.

The icon is wrong for ED faction. I couldn't figure how you did it for Power Plant.

All offsets should be 100% true to vanilla, even footprint. I know that a helipad can disappear if there's no room for that in the vanilla game. But honestly, it looks terrible and IMO both should be always there if Air Base is built.
![airbase](https://user-images.githubusercontent.com/17529329/233802372-b23836e1-0db9-4bcd-bc8c-d19b984b0a0f.gif)

![image](https://user-images.githubusercontent.com/17529329/233802390-f46cb986-81b4-406d-925a-eb1da0cc960c.png)

