### PR TITLE
Added HT 30 LR + clean up.

### DIFF
--- a/mods/e2140/content/ed/mod.yaml
+++ b/mods/e2140/content/ed/mod.yaml
@@ -13,6 +13,7 @@ Rules:
 	e2140|content/ed/vehicles/mt200/rules.yaml
 	e2140|content/ed/vehicles/mt201l/rules.yaml
 	e2140|content/ed/vehicles/btti/rules.yaml
+	e2140|content/ed/vehicles/ht30lr/rules.yaml
 	e2140|content/ed/vehicles/ht33r/rules.yaml
 	e2140|content/ed/vehicles/ht34j/rules.yaml
 	e2140|content/ed/vehicles/warhammer/rules.yaml
@@ -33,6 +34,7 @@ Sequences:
 	e2140|content/ed/vehicles/mt200/sequences.yaml
 	e2140|content/ed/vehicles/mt201l/sequences.yaml
 	e2140|content/ed/vehicles/btti/sequences.yaml
+	e2140|content/ed/vehicles/ht30lr/sequences.yaml
 	e2140|content/ed/vehicles/ht33r/sequences.yaml
 	e2140|content/ed/vehicles/ht34j/sequences.yaml
 	e2140|content/ed/vehicles/warhammer/sequences.yaml
@@ -52,6 +54,7 @@ Weapons:
 	e2140|content/ed/vehicles/mt200/weapons.yaml
 	e2140|content/ed/vehicles/mt201l/weapons.yaml
 	e2140|content/ed/vehicles/btti/weapons.yaml
+	e2140|content/ed/vehicles/ht30lr/weapons.yaml
 	e2140|content/ed/vehicles/ht33r/weapons.yaml
 	e2140|content/ed/vehicles/ht34j/weapons.yaml
 	e2140|content/ed/vehicles/warhammer/weapons.yaml

--- a/mods/e2140/content/ed/vehicles/ht30lr/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/ht30lr/rules.yaml
@@ -1,0 +1,73 @@
+ed_vehicles_ht30lr:
+	Inherits@1: ^EdVehicle
+	Inherits@2: ^CoreTurret
+	Tooltip:
+		Name: HT 30 LR
+	Valued:
+		Cost: 1500
+	Buildable:
+		IconPalette:
+		Queue: Vehicle.ED
+		BuildDuration: 60
+	Selectable:
+		Bounds: 944, 784, 0, 0
+	Health:
+		HP: 600
+	Mobile:
+		Speed: 50
+	RevealsShroud:
+		Range: 2c896
+	Turreted@PRIMARY:
+		Turret: primary
+	Turreted@SECONDARY:
+		Turret: secondary
+		TurnSpeed: 30
+		Offset: 0,0,230
+	AttackTurreted:
+		Turrets: primary, secondary
+		Armaments: primary, secondary
+	WithSpriteTurret@SECONDARY:
+		Sequence: turret_secondary
+		Turret: secondary
+	Armament@PRIMARY_LASER:
+		Name: primary
+		Turret: primary
+		Weapon: ed_vehicles_ht30lr_laser
+		Recoil: 40
+		RecoilRecovery: 19
+		LocalOffset: 250,200,100
+		MuzzlePalette:
+		PauseOnCondition: !ammo
+	Armament@SECONDARY_LASER:
+		Name: primary
+		Turret: primary
+		Weapon: ed_vehicles_ht30lr_laser
+		Recoil: 40
+		RecoilRecovery: 19
+		LocalOffset: 250,-200,100
+		MuzzlePalette:
+		PauseOnCondition: !ammo
+	Armament@MISSILES:
+		Name: secondary
+		Turret: secondary
+		Weapon: ed_vehicles_ht30lr_missiles
+		Recoil: 80
+		RecoilRecovery: 38
+		LocalOffset: 100,100,0,100,-100,0
+		MuzzlePalette:
+	Armament@MISSILES_AIR:
+		Name: secondary
+		Turret: secondary
+		Weapon: ed_vehicles_ht30lr_missiles_air
+		Recoil: 80
+		RecoilRecovery: 38
+		LocalOffset: 100,100,0,100,-100,0
+		MuzzlePalette:
+	AmmoPool:
+		Armaments: primary
+		Ammo: 30
+		AmmoCondition: ammo
+	ReloadAmmoPool:
+		Delay: 50
+		#ResetOnFire: True #TODO Secondary turret resets the timer when it shoots but it shouldn't.
+		Count: 20

--- a/mods/e2140/content/ed/vehicles/ht30lr/sequences.yaml
+++ b/mods/e2140/content/ed/vehicles/ht30lr/sequences.yaml
@@ -1,0 +1,31 @@
+ed_vehicles_ht30lr:
+	idle:
+		Filename: vehicle_tank_large.vspr
+		Facings: -16
+	move:
+		Filename: vehicle_tank_large.vspr
+		Start: 16
+		Length: 4
+		Facings: -16
+	turret:
+		Filename: turret_ht_30_lr.vspr
+		Facings: -16
+		Offset: 1, -7
+	turret_secondary:
+		Filename: turret_ht_30_lr_secondary.vspr
+		Facings: -16
+		Offset: 0, 0
+	icon:
+		Filename: SPRI0.MIX
+		Start: 139
+	# TODO: Enable after PR #20705 is merged in OpenRA
+	#icon-ucs:
+	#	Filename: SPRI1.MIX
+	#	Start: 139
+
+# TODO: remove after PR #20705
+ed_vehicles_ht30lr.ucs:
+	Inherits: ed_vehicles_ht30lr
+	icon:
+		Filename: SPRI1.MIX
+		Start: 139

--- a/mods/e2140/content/ed/vehicles/ht30lr/weapons.yaml
+++ b/mods/e2140/content/ed/vehicles/ht30lr/weapons.yaml
@@ -1,0 +1,84 @@
+ed_vehicles_ht30lr_laser:
+	ReloadDelay: 50
+	Range: 2c896
+	MinRange: 0c512
+	Report: 10.smp
+	ValidTargets: Ground, Water
+	Burst: 15
+	BurstDelays: 3
+	Projectile: LaserZap
+		HitAnimPalette:
+		LaunchEffectPalette:
+		Duration: 5
+		ZOffset: 512
+		Width: 0c20
+		Color: FF4935
+		SecondaryBeam: True
+		SecondaryBeamWidth: 0c35
+		SecondaryBeamColor: FF4935
+	Warhead@Damage: SpreadDamage
+		Spread: 128
+		Damage: 16
+		ValidTargets: Ground
+	Warhead@Effect: CreateEffect
+		Image: smoke
+		Explosions: idle
+		ExplosionPalette:
+		ValidTargets: Ground, Water
+
+ed_vehicles_ht30lr_missiles:
+	Inherits: Smudges
+	ReloadDelay: 48
+	Range: 4c896
+	MinRange: 0c512
+	Report: 5.smp
+	ValidTargets: Ground, Water
+	Burst: 4
+	BurstDelays: 6
+	Projectile: Missile
+		Speed: 260
+		Arm: 2
+		Blockable: false
+		Inaccuracy: 128
+		Image: projectile_rocket
+		Palette:
+		TrailImage: missile_trail
+		TrailInterval: 0
+		TrailPalette:
+		Shadow: True
+		ShadowColor: 00000046
+		HorizontalRateOfTurn: 20
+	Warhead@DamageGround: SpreadDamage
+		Spread: 128
+		Damage: 15
+		ValidTargets: Ground
+	Warhead@DamageAir: SpreadDamage
+		Spread: 128
+		Damage: 15
+		ValidTargets: Air
+	Warhead@EffectGround: CreateEffect
+		Image: projectile_rocket
+		Explosions: explode
+		ExplosionPalette:
+		ImpactSounds: 14.smp
+		ValidTargets: Ground
+		InvalidTargets: Vehicle, Structure, Air
+	Warhead@EffectActor: CreateEffect
+		Image: projectile_cannon
+		Explosions: explode, explode2
+		ExplosionPalette:
+		ImpactSounds: 15.smp
+		ValidTargets: Vehicle, Structure, Air
+	Warhead@EffectWater: CreateEffect
+		Image: water_splash
+		Explosions: idle
+		ExplosionPalette:
+		ImpactSounds: 20.smp, 21.smp
+		ValidTargets: Water
+		InvalidTargets: Vehicle, Structure, Air
+
+ed_vehicles_ht30lr_missiles_air:
+	Inherits: ed_vehicles_st02
+	ValidTargets: Air
+	Projectile: Missile
+		Inaccuracy: 2c0

--- a/mods/e2140/content/ed/vehicles/ht33r/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/ht33r/rules.yaml
@@ -2,7 +2,7 @@ ed_vehicles_ht33r:
 	Inherits@1: ^EdVehicle
 	Inherits@2: ^CoreTurret
 	Tooltip:
-		Name: HR 33 R
+		Name: HT 33 R
 	Valued:
 		Cost: 1200
 	Buildable:

--- a/mods/e2140/content/ed/vehicles/ht34j/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/ht34j/rules.yaml
@@ -2,7 +2,7 @@ ed_vehicles_ht34j:
 	Inherits@1: ^EdVehicle
 	Inherits@2: ^CoreTurret
 	Tooltip:
-		Name: HR 34 J
+		Name: HT 34 J
 	Valued:
 		Cost: 1200
 	Buildable:

--- a/mods/e2140/virtualassets/SPRU0.MIX.VirtualAssets.yaml
+++ b/mods/e2140/virtualassets/SPRU0.MIX.VirtualAssets.yaml
@@ -121,7 +121,7 @@ Generate:
 	turret_kt30:
 		idle: 378-386 16
 
-	turret_ht_30_lr:
+	turret_ht_30_lr_secondary:
 		idle: 387-395 16
 
 	turret_kt30_secondary:
@@ -136,7 +136,7 @@ Generate:
 	turret_little_eye:
 		idle: 396-404 16
 
-	turret_ht_30_lr_secondary: Player
+	turret_ht_30_lr: Player
 		idle: 405-413 16
 
 	turret_ht_34_j: Shadow


### PR DESCRIPTION
- In the original game, HT's turrets can shoot independently. OpenRA engine does not support this behavior by default. Right now both turrets will always target the same actor.
- Due to the aboves statement, HT will stop and shoot as soon as a target is in secondary's turret range. 
- There's a probably a bug or an oversight in `ReloadAmmoPool` trait. It has `ResetOnFire = True` parameter which by default works correctly. However the problem arrises when an actor uses at least two different turrets with two different types of armament where at least one has own ammo pool. That means when a secondary turret shoots, it resets reload timer of the primary armament. Timer reset should only happen for the primary weapon. This might require fixing in the engine.

And fixed wrong names for two other HT units.

![ht30lr](https://user-images.githubusercontent.com/17529329/235326665-465a972f-a392-4c77-aae2-6e7be5dca44f.gif)

