### PR TITLE
Fixed wrong strafing run for bombers.

### DIFF
--- a/mods/e2140/content/ed/aircrafts/nemezis/rules.yaml
+++ b/mods/e2140/content/ed/aircrafts/nemezis/rules.yaml
@@ -20,8 +20,9 @@ ed_aircrafts_nemezis:
 	Armament@PRIMARY:
 		Weapon: ed_aircrafts_nemezis
 		MuzzlePalette:
-	AttackAircraft:
-		StrafeRunLength: 6c0
+	Armament@SECONDARY:
+		Weapon: ed_aircrafts_nemezis_targeting
+		MuzzlePalette:
 	WithMoveAnimation:
 		ValidMovementTypes: Horizontal, Vertical, Turn
 	SpawnActorOnDeath:

--- a/mods/e2140/content/ed/aircrafts/nemezis/weapons.yaml
+++ b/mods/e2140/content/ed/aircrafts/nemezis/weapons.yaml
@@ -21,3 +21,9 @@ ed_aircrafts_nemezis:
 		ExplosionPalette:
 		ImpactSounds: 14.smp
 		ValidTargets: Ground
+
+ed_aircrafts_nemezis_targeting:
+	ReloadDelay: 900
+	Range: 6c896
+	ValidTargets: Ground, Water
+	Projectile: InstantHit

--- a/mods/e2140/content/shared/sequences/projectiles.yaml
+++ b/mods/e2140/content/shared/sequences/projectiles.yaml
@@ -78,6 +78,7 @@ projectile_ion:
 projectile_bomb:
 	Defaults:
 		Filename: projectile_bomb.vspr
+		ZOffset: -64
 	idle:
 		Length: 2
 
@@ -85,6 +86,7 @@ projectile_plasma_bomb:
 	Defaults:
 		Filename: projectile_plasma_bomb.vspr
 	idle:
+		ZOffset: -64
 	explode:
 		BlendMode: Additive
 		Start: 1

--- a/mods/e2140/content/ucs/aircrafts/hell_wind/rules.yaml
+++ b/mods/e2140/content/ucs/aircrafts/hell_wind/rules.yaml
@@ -18,9 +18,14 @@ ucs_aircrafts_hell_wind:
 	RevealsShroud:
 		Range: 3c896
 	Armament@PRIMARY:
+		Name: primary
 		Weapon: ucs_aircrafts_hell_wind
 		MuzzlePalette:
 		PauseOnCondition: !ammo
+	Armament@SECONDARY:
+		Name: secondary
+		Weapon: ucs_aircrafts_hell_wind_targeting
+		MuzzlePalette:
 	WithMoveAnimation:
 		ValidMovementTypes: Horizontal, Vertical, Turn
 	WithMoveSound:
@@ -29,6 +34,7 @@ ucs_aircrafts_hell_wind:
 		Actor: ucs_aircrafts_hell_wind_husk
 		RequiresCondition: airborne
 	AmmoPool:
+		Armaments: primary
 		Ammo: 7
 		AmmoCondition: ammo
 	ReloadAmmoPool:

--- a/mods/e2140/content/ucs/aircrafts/hell_wind/weapons.yaml
+++ b/mods/e2140/content/ucs/aircrafts/hell_wind/weapons.yaml
@@ -29,3 +29,9 @@ ucs_aircrafts_hell_wind:
 		ImpactSounds: 20.smp, 21.smp
 		ValidTargets: Water
 		InvalidTargets: Vehicle, Structure
+
+ucs_aircrafts_hell_wind_targeting:
+	ReloadDelay: 100
+	Range: 6c896
+	ValidTargets: Ground, Water
+	Projectile: InstantHit


### PR DESCRIPTION
Current strafing run for bombers looks awful as they use strafing run length for primary weapon. Adding 2nd blank weapon which has longer range fixes the issue.

Technically I set:
`	AttackAircraft:
		StrafeRunLength: 6c0` for Nemesis, but it didn't do any effect. From what I can see, no official ORA mod uses that parameter. I am not sure if I understand this parameter correctly. So in the end, I removed that.

Plus adjusted ZOffset for bombs, so they spawn below bombers.

Old:
![strafingrunold](https://user-images.githubusercontent.com/17529329/236004426-ede15f0c-98ad-4326-9402-c354a0d8877e.gif)

New:
![strafingrunnew](https://user-images.githubusercontent.com/17529329/236004449-7ba4e4bf-eab3-43ad-a899-507045ccd704.gif)
