### PR TITLE
Adjusted `TurnDuration` for `WithMovingSpriteTurret`.

### DIFF
--- a/mods/e2140/content/ucs/rules.yaml
+++ b/mods/e2140/content/ucs/rules.yaml
@@ -18,6 +18,7 @@ World:
 	Inherits@2: ^CoreTurret
 	-WithSpriteTurret:
 	WithMovingSpriteTurret:
+		TurnDuration: 750
 	WithTurretShadow:
 		ShadowColor: 00000046
 		Offset: 0,32,-300


### PR DESCRIPTION
750 feels better than 1000. Just IMO right now it's jumping too fast and in original game it's not that fast either.