### PR TITLE
Added Teleport

### DIFF
--- a/OpenRA.Mods.OpenE2140/Traits/ProductionSound.cs
+++ b/OpenRA.Mods.OpenE2140/Traits/ProductionSound.cs
@@ -1,0 +1,45 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenE2140 Developers and Contributors
+ * This file is part of OpenE2140, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Traits.Render;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.OpenE2140.Traits
+{
+	public class ProductionSoundInfo : ConditionalTraitInfo, Requires<RenderSpritesInfo>
+	{
+		[FieldLoader.Require]
+		public readonly string[] Files = null;
+
+		public override object Create(ActorInitializer init) { return new ProductionSound(this); }
+	}
+
+	public class ProductionSound : ConditionalTrait<ProductionSoundInfo>, INotifyProduction
+	{
+		readonly ProductionSoundInfo info;
+
+		public ProductionSound(ProductionSoundInfo info)
+			: base(info)
+		{
+			this.info = info;
+		}
+
+		void INotifyProduction.UnitProduced(Actor self, Actor other, CPos exit)
+		{
+			if (IsTraitDisabled)
+				return;
+
+			foreach (var file in info.Files)
+				Game.Sound.PlayToPlayer(SoundType.World, self.Owner, file, other.CenterPosition);
+		}
+	}
+}

--- a/OpenRA.Mods.OpenE2140/Traits/Rendering/WithProductionExitOverlay.cs
+++ b/OpenRA.Mods.OpenE2140/Traits/Rendering/WithProductionExitOverlay.cs
@@ -1,0 +1,71 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenE2140 Developers and Contributors
+ * This file is part of OpenE2140, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Traits.Render;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.OpenE2140.Traits.Rendering
+{
+	[Desc("Rendered when an actor finishes production on the used exit cell.")]
+	public class WithProductionExitOverlayInfo : ConditionalTraitInfo, Requires<RenderSpritesInfo>
+	{
+		[FieldLoader.Require]
+		[Desc("Exit offset associated with the animation.")]
+		public readonly CVec ExitCell = new(0, 0);
+
+		[SequenceReference]
+		[FieldLoader.Require]
+		[Desc("Sequence name to use.")]
+		public readonly string Sequence = "idle";
+
+		[PaletteReference("IsPlayerPalette")]
+		[Desc("Custom palette name.")]
+		public readonly string Palette = "effect";
+
+		[Desc("Custom palette is a player palette BaseName.")]
+		public readonly bool IsPlayerPalette = false;
+
+		public override object Create(ActorInitializer init) { return new WithProductionExitOverlay(init, this); }
+	}
+
+	public class WithProductionExitOverlay : ConditionalTrait<WithProductionExitOverlayInfo>, INotifyProduction
+	{
+		readonly WithProductionExitOverlayInfo info;
+		readonly Animation overlay;
+
+		bool active;
+
+		public WithProductionExitOverlay(ActorInitializer init, WithProductionExitOverlayInfo info)
+			: base(info)
+		{
+			this.info = info;
+			var renderSprites = init.Self.Trait<RenderSprites>();
+
+			overlay = new Animation(init.World, renderSprites.GetImage(init.Self));
+			renderSprites.Add(new AnimationWithOffset(overlay, null, () => !active), info.Palette, info.IsPlayerPalette);
+		}
+
+		void INotifyProduction.UnitProduced(Actor self, Actor other, CPos exit)
+		{
+			if (IsTraitDisabled)
+				return;
+
+			if (info.ExitCell == exit - self.Location)
+			{
+				active = true;
+				var sequence = RenderSprites.NormalizeSequence(overlay, self.GetDamageState(), info.Sequence);
+				overlay.PlayThen(sequence, () => active = false);
+			}
+		}
+	}
+}

--- a/mods/e2140/content/ucs/buildings/teleport/rules.yaml
+++ b/mods/e2140/content/ucs/buildings/teleport/rules.yaml
@@ -1,0 +1,75 @@
+ucs_buildings_teleport:
+	Inherits: ^CoreFactory
+	Tooltip:
+		Name: Teleport
+	Health:
+		HP: 200
+	Building:
+		Dimensions: 3,3
+		Footprint: xxx xxx ===
+		LocalCenterOffset: 0,-460,0
+	TransformSequence:
+		Offset: -15,430,0
+	HitShape:
+		TargetableOffsets: 600,-312,0,   600,312,0,   -200,-312,0,   -200,312,0
+		Type: Rectangle
+			TopLeft: -1024, -840
+			BottomRight: 1024, 740
+	Selectable:
+		Bounds: 3088, 1950, 0, 0
+	Power:
+		Amount: -700
+	WithIdleOverlay@Powered:
+		Sequence: idle-lights
+		RequiresCondition: !Transforming && Powered
+	WithNightLightSource:
+		RequiresCondition: !Transforming && Powered
+	Production:
+		Produces: Vehicle.UCS
+		RequiresCondition: !Transforming
+	ProductionQueue:
+		Type: Vehicle.UCS
+		Factions: ucs
+		Group: Vehicle
+		LowPowerModifier: 150
+		BuildDurationModifier: 1
+	ProductionBar:
+		ProductionType: Vehicle.UCS
+	ProductionCostMultiplier:
+		Multiplier: 20
+		Queue: Vehicle.UCS
+	ProvidesPrerequisite:
+	Exit@Exit:
+		SpawnOffset: 0,0,0
+		ExitCell: 1,2
+		ExitDelay: 10
+		Facing: 500
+	WithProductionExitOverlay@Exit:
+		ExitCell: 1,2
+		Sequence: teleportation
+		Palette:
+		RequiresCondition: !Transforming
+	ProductionSound:
+		Files: 129.smp
+	Encyclopedia:
+		Category: UCS - Buildings
+		Order: 4
+		Animation: DATABASE/X02.FLC
+		Title: Teleport
+		Armor: None
+		Armament: None
+		Resistance: Medium
+		Description: Teleport makes it possible to take delivery of goods directly from the main underground base. The items to be transported are first dematerialized and then re-materialized in the Teleport. This process not only requires large quantities of energy, it is also very expensive. So vehicles acquired in this way are more expensive than if they were built at the point of delivery. There are many situations which justify this higher price; for example, when the main base is under enemy attack. In this case, it is better to pay the higher price and have the vehicles delivered quickly.
+
+ucs_mcu_teleport:
+	Inherits@1: ^SharedVehicleMcu
+	Tooltip:
+		Name: Mobile Teleport
+	Transforms:
+		IntoActor: ucs_buildings_teleport
+	Valued:
+		Cost: 2150
+	Buildable:
+		IconPalette:
+		Queue: Building.UCS
+		BuildDuration: 40

--- a/mods/e2140/content/ucs/buildings/teleport/sequences.yaml
+++ b/mods/e2140/content/ucs/buildings/teleport/sequences.yaml
@@ -1,0 +1,51 @@
+ucs_buildings_teleport:
+	Defaults:
+		Filename: building_teleport.vspr
+		Offset: 0, 0, 0
+		ZOffset: -351
+	idle:
+	idle-lights:
+		Start: 1
+		IgnoreWorldTint: true
+	damaged-idle:
+		Start: 2
+	damaged-idle-lights:
+		Start: 3
+		IgnoreWorldTint: true
+	teleportation:
+		Combine:
+			0:
+				Filename: GRAPH/SHCKV30.DAT
+			1:
+				Filename: GRAPH/SHCKV31.DAT
+			2:
+				Filename: GRAPH/SHCKV32.DAT
+			3:
+				Filename: GRAPH/SHCKV33.DAT
+			4:
+				Filename: GRAPH/SHCKV34.DAT
+			5:
+				Filename: GRAPH/SHCKV35.DAT
+			6:
+				Filename: GRAPH/SHCKV36.DAT
+			7:
+				Filename: GRAPH/SHCKV37.DAT
+			8:
+				Filename: GRAPH/SHCKV38.DAT
+		BlendMode: Additive
+		Length: 9
+		Offset: 3,-3
+		IgnoreWorldTint: true
+		ZOffset: 256
+
+ucs_mcu_teleport:
+	Inherits: shared_mcu
+	icon:
+		Filename: SPRI1.MIX
+		Start: 176
+
+ucs_mcu_teleport.ed:
+	Inherits: shared_mcu
+	icon:
+		Filename: SPRI0.MIX
+		Start: 176

--- a/mods/e2140/content/ucs/mod.yaml
+++ b/mods/e2140/content/ucs/mod.yaml
@@ -9,6 +9,7 @@ Rules:
 	e2140|content/ucs/buildings/heavy_tech/rules.yaml
 	e2140|content/ucs/buildings/prod_center/rules.yaml
 	e2140|content/ucs/buildings/robot_factory/rules.yaml
+	e2140|content/ucs/buildings/teleport/rules.yaml
 	e2140|content/ucs/vehicles/t100/rules.yaml
 	e2140|content/ucs/vehicles/raptor_es/rules.yaml
 	e2140|content/ucs/vehicles/raptor_ad/rules.yaml
@@ -36,6 +37,7 @@ Sequences:
 	e2140|content/ucs/buildings/heavy_tech/sequences.yaml
 	e2140|content/ucs/buildings/prod_center/sequences.yaml
 	e2140|content/ucs/buildings/robot_factory/sequences.yaml
+	e2140|content/ucs/buildings/teleport/sequences.yaml
 	e2140|content/ucs/vehicles/t100/sequences.yaml
 	e2140|content/ucs/vehicles/raptor_es/sequences.yaml
 	e2140|content/ucs/vehicles/raptor_ad/sequences.yaml

--- a/mods/e2140/maps/testmap_ucs/map.yaml
+++ b/mods/e2140/maps/testmap_ucs/map.yaml
@@ -333,5 +333,9 @@ Actors:
 		SubCell: 1
 		Facing: 384
 		Location: 20,6
+	Actor74: ucs_mcu_teleport
+		Owner: UCS_Player
+		Facing: 384
+		Location: 19,15
 
 Rules: rules.yaml


### PR DESCRIPTION
~~Depends on #181 due to overlay production animation which I also used here. I dunno if you want it like that or provide something better. Also used custom trait to play sound when production is done.~~

~~It's not fully finished yet.~~

I believe I've done everything I could via yaml code.

IMO either `AnimatedExitProduction` needs support for Teleporter animation (and production sound) or we use traits I used.

https://github.com/OpenE2140/OpenE2140/assets/17529329/117bfd0a-5cdf-497e-853c-387ab2e98abf

