### PR TITLE
Removed moving sound from Gargoil II.

### DIFF
--- a/mods/e2140/content/ucs/aircrafts/gargoil2/rules.yaml
+++ b/mods/e2140/content/ucs/aircrafts/gargoil2/rules.yaml
@@ -23,8 +23,6 @@ ucs_aircrafts_gargoil_ii:
 		MuzzlePalette:
 	WithMoveAnimation:
 		ValidMovementTypes: Horizontal, Vertical, Turn
-	WithMoveSound:
-		Sound: 29.smp
 	SpawnActorOnDeath:
 		Actor: ucs_aircrafts_gargoil_ii_husk
 		RequiresCondition: airborne


### PR DESCRIPTION
Gargoil II is not a helicopter. It doesn't need propeller sound when it moves.