### PR TITLE
Fixed wrong shadow for TTRE unit.

### DIFF
--- a/mods/e2140/virtualassets/units.VirtualAssets.yaml
+++ b/mods/e2140/virtualassets/units.VirtualAssets.yaml
@@ -123,6 +123,10 @@ Palettes:
 		253: 0 0 0 32
 		254: 0 0 0 64
 
+	ShadowTTRE: Merge
+		240: 0 0 0 64
+		254: 0 0 0 64
+
 	Husk: Merge Multiply
 		0-239[1_1_0]: 128 128 128
 		240-243: 0 0 0
@@ -416,7 +420,7 @@ Generate:
 		move: 607-615 16 4
 		flicker: 607-615 16 2 FlickerOn
 
-	ship_ttre_400: Shadow Player
+	ship_ttre_400: ShadowTTRE Player
 		idle: 616-624 16
 			Offsets: 616-624:-1,0
 


### PR DESCRIPTION
Before:
![image](https://github.com/OpenE2140/OpenE2140/assets/17529329/fbbbe0f2-6c4e-4444-ba0c-64a2887b7289)
After:
![image](https://github.com/OpenE2140/OpenE2140/assets/17529329/9ec521de-b92a-4187-8e51-1aed9750ca9e)

I decided to make special case shadow palette only for TTRE since index 240 is also used for tracks, rotors or engine. This ensures nothing else is broken.

It's worth noting this bright blue color appears to be only used for this sprite.