### PR TITLE
Allowed vehicles and infantry to travel shore tiles.

### DIFF
--- a/mods/e2140/content/core/rules/defaults.yaml
+++ b/mods/e2140/content/core/rules/defaults.yaml
@@ -329,6 +329,7 @@
 			SandEdge: 100
 			Road: 100
 			AsphaltRoad: 100
+			ShoreEdge: 50
 
 # Base for all vehicles
 ^CoreVehicle:
@@ -403,6 +404,7 @@
 			SandEdge: 50
 			Road: 100
 			AsphaltRoad: 100
+			ShoreEdge: 50
 	Locomotor@vehicleFastSand:
 		Name: vehicleFastSand
 		Crushes: infantry, mine
@@ -413,6 +415,7 @@
 			SandEdge: 100
 			Road: 100
 			AsphaltRoad: 100
+			ShoreEdge: 50
 
 # Base for all aircrafts
 ^CoreAircraft:

--- a/mods/e2140/content/ed/ships/wtrn/rules.yaml
+++ b/mods/e2140/content/ed/ships/wtrn/rules.yaml
@@ -36,3 +36,4 @@ ed_ships_wtrn:
 		TerrainSpeeds:
 			Water: 100
 			Shore: 100
+			ShoreEdge: 100

--- a/mods/e2140/content/ucs/vehicles/wtp_100/rules.yaml
+++ b/mods/e2140/content/ucs/vehicles/wtp_100/rules.yaml
@@ -45,3 +45,4 @@ ucs_vehicles_wtp_100:
 			AsphaltRoad: 100
 			Water: 100
 			Shore: 100
+			ShoreEdge: 100

--- a/mods/e2140/tilesets/desert.yaml
+++ b/mods/e2140/tilesets/desert.yaml
@@ -9,6 +9,10 @@ Terrain:
 		Type: Shore
 		TargetTypes: Ground
 		Color: B09C78
+	TerrainType@ShoreEdge:
+		Type: ShoreEdge
+		TargetTypes: Ground
+		Color: B09C78
 	TerrainType@Clear:
 		Type: Clear
 		TargetTypes: Ground
@@ -464,10 +468,10 @@ Templates:
 		Categories: Shore
 		Frames: 135, 136, 137, 138
 		Tiles:
-			0: Shore
-			1: Shore
-			2: Shore
-			3: Shore
+			0: ShoreEdge
+			1: ShoreEdge
+			2: ShoreEdge
+			3: ShoreEdge
 	Template@108:
 		Id: 108
 		Images: SPRT1.MIX
@@ -476,10 +480,10 @@ Templates:
 		Categories: Shore
 		Frames: 139, 140, 141, 142
 		Tiles:
-			0: Shore
-			1: Shore
-			2: Shore
-			3: Shore
+			0: ShoreEdge
+			1: ShoreEdge
+			2: ShoreEdge
+			3: ShoreEdge
 	Template@109:
 		Id: 109
 		Images: SPRT1.MIX
@@ -488,9 +492,9 @@ Templates:
 		Categories: Shore
 		Frames: 175, 176, 182
 		Tiles:
-			0: Shore
-			1: Shore
-			2: Shore
+			0: ShoreEdge
+			1: ShoreEdge
+			2: ShoreEdge
 	Template@110:
 		Id: 110
 		Images: SPRT1.MIX
@@ -499,9 +503,9 @@ Templates:
 		Categories: Shore
 		Frames: 177, 178, 181
 		Tiles:
-			0: Shore
-			1: Shore
-			2: Shore
+			0: ShoreEdge
+			1: ShoreEdge
+			2: ShoreEdge
 	Template@111:
 		Id: 111
 		Images: SPRT1.MIX
@@ -658,8 +662,8 @@ Templates:
 		Categories: Shore
 		Frames: 167, 173
 		Tiles:
-			0: Shore
-			1: Shore
+			0: ShoreEdge
+			1: ShoreEdge
 	Template@128:
 		Id: 128
 		Images: SPRT1.MIX
@@ -668,8 +672,8 @@ Templates:
 		Categories: Shore
 		Frames: 168, 171
 		Tiles:
-			0: Shore
-			1: Shore
+			0: ShoreEdge
+			1: ShoreEdge
 	Template@129:
 		Id: 129
 		Images: SPRT1.MIX
@@ -678,8 +682,8 @@ Templates:
 		Categories: Shore
 		Frames: 169, 172
 		Tiles:
-			0: Shore
-			1: Shore
+			0: ShoreEdge
+			1: ShoreEdge
 	Template@130:
 		Id: 130
 		Images: SPRT1.MIX
@@ -688,8 +692,8 @@ Templates:
 		Categories: Shore
 		Frames: 170, 174
 		Tiles:
-			0: Shore
-			1: Shore
+			0: ShoreEdge
+			1: ShoreEdge
 
 	# Road tiles
 	Template@200:

--- a/mods/e2140/tilesets/sandy.yaml
+++ b/mods/e2140/tilesets/sandy.yaml
@@ -9,6 +9,10 @@ Terrain:
 		Type: Shore
 		TargetTypes: Ground
 		Color: B09C78
+	TerrainType@ShoreEdge:
+		Type: ShoreEdge
+		TargetTypes: Ground
+		Color: B09C78
 	TerrainType@Clear:
 		Type: Clear
 		TargetTypes: Ground
@@ -464,10 +468,10 @@ Templates:
 		Categories: Shore
 		Frames: 135, 136, 137, 138
 		Tiles:
-			0: Shore
-			1: Shore
-			2: Shore
-			3: Shore
+			0: ShoreEdge
+			1: ShoreEdge
+			2: ShoreEdge
+			3: ShoreEdge
 	Template@108:
 		Id: 108
 		Images: SPRT2.MIX
@@ -476,10 +480,10 @@ Templates:
 		Categories: Shore
 		Frames: 139, 140, 141, 142
 		Tiles:
-			0: Shore
-			1: Shore
-			2: Shore
-			3: Shore
+			0: ShoreEdge
+			1: ShoreEdge
+			2: ShoreEdge
+			3: ShoreEdge
 	Template@109:
 		Id: 109
 		Images: SPRT2.MIX
@@ -488,9 +492,9 @@ Templates:
 		Categories: Shore
 		Frames: 175, 176, 182
 		Tiles:
-			0: Shore
-			1: Shore
-			2: Shore
+			0: ShoreEdge
+			1: ShoreEdge
+			2: ShoreEdge
 	Template@110:
 		Id: 110
 		Images: SPRT2.MIX
@@ -499,9 +503,9 @@ Templates:
 		Categories: Shore
 		Frames: 177, 178, 181
 		Tiles:
-			0: Shore
-			1: Shore
-			2: Shore
+			0: ShoreEdge
+			1: ShoreEdge
+			2: ShoreEdge
 	Template@111:
 		Id: 111
 		Images: SPRT2.MIX
@@ -658,8 +662,8 @@ Templates:
 		Categories: Shore
 		Frames: 167, 173
 		Tiles:
-			0: Shore
-			1: Shore
+			0: ShoreEdge
+			1: ShoreEdge
 	Template@128:
 		Id: 128
 		Images: SPRT2.MIX
@@ -668,8 +672,8 @@ Templates:
 		Categories: Shore
 		Frames: 168, 171
 		Tiles:
-			0: Shore
-			1: Shore
+			0: ShoreEdge
+			1: ShoreEdge
 	Template@129:
 		Id: 129
 		Images: SPRT2.MIX
@@ -678,8 +682,8 @@ Templates:
 		Categories: Shore
 		Frames: 169, 172
 		Tiles:
-			0: Shore
-			1: Shore
+			0: ShoreEdge
+			1: ShoreEdge
 	Template@130:
 		Id: 130
 		Images: SPRT2.MIX
@@ -688,8 +692,8 @@ Templates:
 		Categories: Shore
 		Frames: 170, 174
 		Tiles:
-			0: Shore
-			1: Shore
+			0: ShoreEdge
+			1: ShoreEdge
 
 	# Road tiles
 	Template@200:

--- a/mods/e2140/tilesets/snow.yaml
+++ b/mods/e2140/tilesets/snow.yaml
@@ -9,6 +9,10 @@ Terrain:
 		Type: Shore
 		TargetTypes: Ground
 		Color: B09C78
+	TerrainType@ShoreEdge:
+		Type: ShoreEdge
+		TargetTypes: Ground
+		Color: B09C78
 	TerrainType@Clear:
 		Type: Clear
 		TargetTypes: Ground
@@ -464,10 +468,10 @@ Templates:
 		Categories: Shore
 		Frames: 135, 136, 137, 138
 		Tiles:
-			0: Shore
-			1: Shore
-			2: Shore
-			3: Shore
+			0: ShoreEdge
+			1: ShoreEdge
+			2: ShoreEdge
+			3: ShoreEdge
 	Template@108:
 		Id: 108
 		Images: SPRT4.MIX
@@ -476,10 +480,10 @@ Templates:
 		Categories: Shore
 		Frames: 139, 140, 141, 142
 		Tiles:
-			0: Shore
-			1: Shore
-			2: Shore
-			3: Shore
+			0: ShoreEdge
+			1: ShoreEdge
+			2: ShoreEdge
+			3: ShoreEdge
 	Template@109:
 		Id: 109
 		Images: SPRT4.MIX
@@ -488,9 +492,9 @@ Templates:
 		Categories: Shore
 		Frames: 175, 176, 182
 		Tiles:
-			0: Shore
-			1: Shore
-			2: Shore
+			0: ShoreEdge
+			1: ShoreEdge
+			2: ShoreEdge
 	Template@110:
 		Id: 110
 		Images: SPRT4.MIX
@@ -499,9 +503,9 @@ Templates:
 		Categories: Shore
 		Frames: 177, 178, 181
 		Tiles:
-			0: Shore
-			1: Shore
-			2: Shore
+			0: ShoreEdge
+			1: ShoreEdge
+			2: ShoreEdge
 	Template@111:
 		Id: 111
 		Images: SPRT4.MIX
@@ -658,8 +662,8 @@ Templates:
 		Categories: Shore
 		Frames: 167, 173
 		Tiles:
-			0: Shore
-			1: Shore
+			0: ShoreEdge
+			1: ShoreEdge
 	Template@128:
 		Id: 128
 		Images: SPRT4.MIX
@@ -668,8 +672,8 @@ Templates:
 		Categories: Shore
 		Frames: 168, 171
 		Tiles:
-			0: Shore
-			1: Shore
+			0: ShoreEdge
+			1: ShoreEdge
 	Template@129:
 		Id: 129
 		Images: SPRT4.MIX
@@ -678,8 +682,8 @@ Templates:
 		Categories: Shore
 		Frames: 169, 172
 		Tiles:
-			0: Shore
-			1: Shore
+			0: ShoreEdge
+			1: ShoreEdge
 	Template@130:
 		Id: 130
 		Images: SPRT4.MIX
@@ -688,8 +692,8 @@ Templates:
 		Categories: Shore
 		Frames: 170, 174
 		Tiles:
-			0: Shore
-			1: Shore
+			0: ShoreEdge
+			1: ShoreEdge
 
 	# Road tiles
 	Template@200:

--- a/mods/e2140/tilesets/temperate.yaml
+++ b/mods/e2140/tilesets/temperate.yaml
@@ -9,6 +9,10 @@ Terrain:
 		Type: Shore
 		TargetTypes: Ground
 		Color: B09C78
+	TerrainType@ShoreEdge:
+		Type: ShoreEdge
+		TargetTypes: Ground
+		Color: B09C78
 	TerrainType@Clear:
 		Type: Clear
 		TargetTypes: Ground
@@ -464,10 +468,10 @@ Templates:
 		Categories: Shore
 		Frames: 135, 136, 137, 138
 		Tiles:
-			0: Shore
-			1: Shore
-			2: Shore
-			3: Shore
+			0: ShoreEdge
+			1: ShoreEdge
+			2: ShoreEdge
+			3: ShoreEdge
 	Template@108:
 		Id: 108
 		Images: SPRT3.MIX
@@ -476,10 +480,10 @@ Templates:
 		Categories: Shore
 		Frames: 139, 140, 141, 142
 		Tiles:
-			0: Shore
-			1: Shore
-			2: Shore
-			3: Shore
+			0: ShoreEdge
+			1: ShoreEdge
+			2: ShoreEdge
+			3: ShoreEdge
 	Template@109:
 		Id: 109
 		Images: SPRT3.MIX
@@ -488,9 +492,9 @@ Templates:
 		Categories: Shore
 		Frames: 175, 176, 182
 		Tiles:
-			0: Shore
-			1: Shore
-			2: Shore
+			0: ShoreEdge
+			1: ShoreEdge
+			2: ShoreEdge
 	Template@110:
 		Id: 110
 		Images: SPRT3.MIX
@@ -499,9 +503,9 @@ Templates:
 		Categories: Shore
 		Frames: 177, 178, 181
 		Tiles:
-			0: Shore
-			1: Shore
-			2: Shore
+			0: ShoreEdge
+			1: ShoreEdge
+			2: ShoreEdge
 	Template@111:
 		Id: 111
 		Images: SPRT3.MIX
@@ -658,8 +662,8 @@ Templates:
 		Categories: Shore
 		Frames: 167, 173
 		Tiles:
-			0: Shore
-			1: Shore
+			0: ShoreEdge
+			1: ShoreEdge
 	Template@128:
 		Id: 128
 		Images: SPRT3.MIX
@@ -668,8 +672,8 @@ Templates:
 		Categories: Shore
 		Frames: 168, 171
 		Tiles:
-			0: Shore
-			1: Shore
+			0: ShoreEdge
+			1: ShoreEdge
 	Template@129:
 		Id: 129
 		Images: SPRT3.MIX
@@ -678,8 +682,8 @@ Templates:
 		Categories: Shore
 		Frames: 169, 172
 		Tiles:
-			0: Shore
-			1: Shore
+			0: ShoreEdge
+			1: ShoreEdge
 	Template@130:
 		Id: 130
 		Images: SPRT3.MIX
@@ -688,8 +692,8 @@ Templates:
 		Categories: Shore
 		Frames: 170, 174
 		Tiles:
-			0: Shore
-			1: Shore
+			0: ShoreEdge
+			1: ShoreEdge
 
 	# Road tiles
 	Template@200:

--- a/mods/e2140/tilesets/wasteland.yaml
+++ b/mods/e2140/tilesets/wasteland.yaml
@@ -9,6 +9,10 @@ Terrain:
 		Type: Shore
 		TargetTypes: Ground
 		Color: B09C78
+	TerrainType@ShoreEdge:
+		Type: ShoreEdge
+		TargetTypes: Ground
+		Color: B09C78
 	TerrainType@Clear:
 		Type: Clear
 		TargetTypes: Ground
@@ -460,10 +464,10 @@ Templates:
 		Categories: Shore
 		Frames: 135, 136, 137, 138
 		Tiles:
-			0: Shore
-			1: Shore
-			2: Shore
-			3: Shore
+			0: ShoreEdge
+			1: ShoreEdge
+			2: ShoreEdge
+			3: ShoreEdge
 	Template@108:
 		Id: 108
 		Images: SPRT0.MIX
@@ -472,10 +476,10 @@ Templates:
 		Categories: Shore
 		Frames: 139, 140, 141, 142
 		Tiles:
-			0: Shore
-			1: Shore
-			2: Shore
-			3: Shore
+			0: ShoreEdge
+			1: ShoreEdge
+			2: ShoreEdge
+			3: ShoreEdge
 	Template@109:
 		Id: 109
 		Images: SPRT0.MIX
@@ -484,9 +488,9 @@ Templates:
 		Categories: Shore
 		Frames: 175, 176, 182
 		Tiles:
-			0: Shore
-			1: Shore
-			2: Shore
+			0: ShoreEdge
+			1: ShoreEdge
+			2: ShoreEdge
 	Template@110:
 		Id: 110
 		Images: SPRT0.MIX
@@ -495,9 +499,9 @@ Templates:
 		Categories: Shore
 		Frames: 177, 178, 181
 		Tiles:
-			0: Shore
-			1: Shore
-			2: Shore
+			0: ShoreEdge
+			1: ShoreEdge
+			2: ShoreEdge
 	Template@111:
 		Id: 111
 		Images: SPRT0.MIX
@@ -654,8 +658,8 @@ Templates:
 		Categories: Shore
 		Frames: 167, 173
 		Tiles:
-			0: Shore
-			1: Shore
+			0: ShoreEdge
+			1: ShoreEdge
 	Template@128:
 		Id: 128
 		Images: SPRT0.MIX
@@ -664,8 +668,8 @@ Templates:
 		Categories: Shore
 		Frames: 168, 171
 		Tiles:
-			0: Shore
-			1: Shore
+			0: ShoreEdge
+			1: ShoreEdge
 	Template@129:
 		Id: 129
 		Images: SPRT0.MIX
@@ -674,8 +678,8 @@ Templates:
 		Categories: Shore
 		Frames: 169, 172
 		Tiles:
-			0: Shore
-			1: Shore
+			0: ShoreEdge
+			1: ShoreEdge
 	Template@130:
 		Id: 130
 		Images: SPRT0.MIX
@@ -684,8 +688,8 @@ Templates:
 		Categories: Shore
 		Frames: 170, 174
 		Tiles:
-			0: Shore
-			1: Shore
+			0: ShoreEdge
+			1: ShoreEdge
 
 	# Road tiles
 	Template@200:


### PR DESCRIPTION
My main motive for that was HCU-M, so it can repair naval units. In the vanilla game HCU-M can repair naval units as cursor suggests that, but it's not able to reach them as no ground unit can travel shore tiles.

For this reason I allowed ground units to travel shore, but only specific tiles, as some shore tiles have too much water, so it would look out of place.

![repair](https://github.com/OpenE2140/OpenE2140/assets/17529329/f5d88b6a-900c-4c26-bf56-1ecb8b49f3a7)
