### PR TITLE
Unified sequence tick value for machine guns' muzzle flash.

### DIFF
--- a/mods/e2140/content/ed/aircrafts/storm/sequences.yaml
+++ b/mods/e2140/content/ed/aircrafts/storm/sequences.yaml
@@ -16,7 +16,7 @@ ed_aircrafts_storm:
 		Start: 16
 		Length: 3
 		Facings: -16
-		Tick: 60
+		Tick: 50
 	icon:
 		Filename: SPRI0.MIX
 		Start: 161

--- a/mods/e2140/content/ed/vehicles/btti/sequences.yaml
+++ b/mods/e2140/content/ed/vehicles/btti/sequences.yaml
@@ -12,7 +12,7 @@ ed_vehicles_btti:
 		Start: 80
 		Length: 3
 		Facings: -16
-		Tick: 60
+		Tick: 50
 	icon:
 		Filename: SPRI0.MIX
 		Start: 146

--- a/mods/e2140/content/ed/vehicles/miner/sequences.yaml
+++ b/mods/e2140/content/ed/vehicles/miner/sequences.yaml
@@ -14,6 +14,7 @@ ed_vehicles_miner:
 		Filename: turret_miner.vspr
 		Start: 16
 		Length: 3
+		Tick: 50
 		Facings: -16
 	icon:
 		Filename: content/ed/vehicles/miner/vehicle_miner_icon_ed.png

--- a/mods/e2140/content/ed/vehicles/mt200/sequences.yaml
+++ b/mods/e2140/content/ed/vehicles/mt200/sequences.yaml
@@ -16,6 +16,7 @@ ed_vehicles_mt200:
 		Start: 16
 		Length: 3
 		Facings: -16
+		Tick: 50
 		Offset: -1, 6, 0
 	icon:
 		Filename: SPRI0.MIX

--- a/mods/e2140/content/ed/vehicles/st01b/sequences.yaml
+++ b/mods/e2140/content/ed/vehicles/st01b/sequences.yaml
@@ -16,6 +16,7 @@ ed_vehicles_st01b:
 		Start: 16
 		Length: 3
 		Facings: -16
+		Tick: 50
 		Offset: 0, 5, 0
 	icon:
 		Filename: SPRI0.MIX

--- a/mods/e2140/content/ed/vehicles/warhammer/sequences.yaml
+++ b/mods/e2140/content/ed/vehicles/warhammer/sequences.yaml
@@ -15,6 +15,7 @@ ed_vehicles_warhammer:
 		Filename: content/ed/vehicles/warhammer/turret_warhammer_muzzle.png
 		Length: 3
 		Facings: -16
+		Tick: 50
 		Offset: 0,-5
 	icon:
 		Filename: SPRI0.MIX

--- a/mods/e2140/content/ucs/aircrafts/gargoil/sequences.yaml
+++ b/mods/e2140/content/ucs/aircrafts/gargoil/sequences.yaml
@@ -11,7 +11,7 @@ ucs_aircrafts_gargoil:
 		Start: 32
 		Length: 3
 		Facings: -16
-		Tick: 60
+		Tick: 50
 	icon:
 		Filename: SPRI1.MIX
 		Start: 162

--- a/mods/e2140/content/ucs/vehicles/atm_500/sequences.yaml
+++ b/mods/e2140/content/ucs/vehicles/atm_500/sequences.yaml
@@ -16,7 +16,7 @@ ucs_vehicles_atm_500:
 		Start: 16
 		Length: 3
 		Facings: -16
-		Tick: 60
+		Tick: 50
 		Offset: 1,0
 	icon:
 		Filename: SPRI1.MIX

--- a/mods/e2140/content/ucs/vehicles/raptor_es/sequences.yaml
+++ b/mods/e2140/content/ucs/vehicles/raptor_es/sequences.yaml
@@ -19,7 +19,7 @@ ucs_vehicles_raptor_es:
 		Start: 64
 		Length: 3
 		Facings: -16
-		Tick: 60
+		Tick: 50
 	shadow:
 		Filename: raptor_shadow.vspr
 		Facings: -8

--- a/mods/e2140/content/ucs/vehicles/t100/sequences.yaml
+++ b/mods/e2140/content/ucs/vehicles/t100/sequences.yaml
@@ -15,7 +15,7 @@ ucs_vehicles_t100:
 		Start: 16
 		Length: 3
 		Facings: -16
-		Tick: 60
+		Tick: 50
 	icon:
 		Filename: SPRI1.MIX
 		Start: 128


### PR DESCRIPTION
This mainly fixes that https://github.com/OpenE2140/OpenE2140/pull/197, just default tick 40 was too fast for it.

Before:
![236702484-a2920956-e9e5-4830-9ef9-c44440768380](https://github.com/OpenE2140/OpenE2140/assets/17529329/8b5c32d5-a2e6-479a-80e5-812f252dbb38)
After:
![warhammer](https://github.com/OpenE2140/OpenE2140/assets/17529329/902af419-cd05-4b10-b55b-fb8391041265)

