### PR TITLE
Adjusted defense tower explosion offset.

### DIFF
--- a/mods/e2140/content/core/rules/defaults.yaml
+++ b/mods/e2140/content/core/rules/defaults.yaml
@@ -261,8 +261,8 @@
 		RequiresCondition: !Transforming
 	# Towers explode when killed.
 	Explodes:
-		Weapon: BuildingExplosion
-		EmptyWeapon: BuildingExplosion
+		Weapon: TowerExplosion
+		EmptyWeapon: TowerExplosion
 
 # Base for all infantry.
 ^CoreInfantry:

--- a/mods/e2140/content/core/sequences/explosions.yaml
+++ b/mods/e2140/content/core/sequences/explosions.yaml
@@ -30,6 +30,11 @@ building_explosion:
 		Length: 5
 		Offset: 0,-20
 
+tower_explosion:
+	Inherits: building_explosion
+	idle:
+		Offset: 0,0
+
 nuclear_explosion:
 	idle:
 		Combine:

--- a/mods/e2140/content/core/weapons/explosions.yaml
+++ b/mods/e2140/content/core/weapons/explosions.yaml
@@ -30,6 +30,15 @@ BuildingExplosion:
 		ValidTargets: Ground, Water
 		ImpactSounds: 16.smp, 17.smp
 
+TowerExplosion:
+	ValidTargets: Ground, Water
+	Warhead@Effect: CreateEffect
+		Image: tower_explosion
+		Explosions: idle
+		ExplosionPalette:
+		ValidTargets: Ground, Water
+		ImpactSounds: 16.smp, 17.smp
+
 PowerPlantExplosion:
 	ValidTargets: Ground, Water
 	Warhead@Effect: CreateEffect


### PR DESCRIPTION
Basically building explosion and tower explosion were seperated from each other.