### PR TITLE
Infantry units inside BIO will be healed to full HP instantly.

### DIFF
--- a/mods/e2140/content/core/rules/defaults.yaml
+++ b/mods/e2140/content/core/rules/defaults.yaml
@@ -671,11 +671,18 @@
 
 # Infantry units can be healed when they are nearby BIO vehicle.
 ^HealedByBio:
-	ChangesHealth:
+	# Infantry units are healed around BIO vehicle.
+	ChangesHealth@AroundBio:
 		Step: 5
 		Delay: 30
 		StartIfBelow: 100
 		RequiresCondition: healing
+	# Infantry units are healed inside BIO vehicle.
+	ChangesHealth@InsideBio:
+		Step: 500
+		Delay: 5
+		StartIfBelow: 100
+		RequiresCondition: insidebio
 	# External condition granted by BIO vehicle.
 	ExternalCondition@Healing:
 		Condition: healing
@@ -696,6 +703,10 @@
 		Condition: activatebio
 		Range: 2c896
 		RequiresCondition: damaged
+	# Give a condition to infantry units which are inside BIO.
+	Passenger:
+		CargoConditions: 
+			ed_vehicles_bio: insidebio
 
 # Actors can be disabled by ion weapons and repaired by HCU-M.
 ^DisabledActor:

--- a/mods/e2140/content/ed/infantry/a04/rules.yaml
+++ b/mods/e2140/content/ed/infantry/a04/rules.yaml
@@ -33,9 +33,6 @@ ed_infantry_a04:
 	DetectCloaked:
 		Range: 2c896
 		DetectionTypes: LandMine
-	Passenger:
-		CargoConditions: 
-			ed_vehicles_bio: insidebio
 	WithAmmoPipsDecoration:
 		FullSequence: pip-grey
 		Palette:

--- a/mods/e2140/content/ed/vehicles/bio/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/bio/rules.yaml
@@ -22,6 +22,7 @@ ed_vehicles_bio:
 		MaxWeight: 4
 		UnloadVoice: Unload
 		UnloadCursor: exit
+		LoadedCondition: infantryinside
 	WithCargoPipsDecoration:
 		Palette:
 		PipStride: 6,0
@@ -35,7 +36,7 @@ ed_vehicles_bio:
 	WithFacingSpriteBody@Healing:
 		Sequence: healing
 		Name: healing
-		RequiresCondition: activatebio
+		RequiresCondition: activatebio || infantryinside
 	Encyclopedia:
 		Category: ED - Vehicles
 		Order: 9


### PR DESCRIPTION
- Living infantry units inside BIO will be healed to full HP.
- Lights on BIO will be turned on when any living infantry unit is inside (as in vanilla).
- Moved `insidebio` condition to `^HealedByBio`. A04 can still replenish mines in BIO.

Closes #321

![bio](https://github.com/OpenE2140/OpenE2140/assets/17529329/58e3e02c-80a9-4f59-9b42-7fb51bf9dd56)
