### PR TITLE
Increased infantry capacity from 6 to 7 for HAT, TUR and ATM 500.

### DIFF
--- a/mods/e2140/content/ed/aircrafts/hat/rules.yaml
+++ b/mods/e2140/content/ed/aircrafts/hat/rules.yaml
@@ -22,7 +22,7 @@ ed_aircrafts_hat:
 		Sound: 30.smp
 	Cargo:
 		Types: Infantry
-		MaxWeight: 6
+		MaxWeight: 7
 		UnloadVoice: Unload
 		UnloadCursor: exit
 	WithCargoPipsDecoration:

--- a/mods/e2140/content/ed/vehicles/tur/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/tur/rules.yaml
@@ -19,7 +19,7 @@ ed_vehicles_tur:
 		Range: 2c896
 	Cargo:
 		Types: Infantry
-		MaxWeight: 6
+		MaxWeight: 7
 		UnloadVoice: Unload
 		UnloadCursor: exit
 	WithCargoPipsDecoration:

--- a/mods/e2140/content/ucs/vehicles/atm_500/rules.yaml
+++ b/mods/e2140/content/ucs/vehicles/atm_500/rules.yaml
@@ -29,7 +29,7 @@ ucs_vehicles_atm_500:
 	WithMuzzleOverlay@muzzle:
 	Cargo:
 		Types: Infantry
-		MaxWeight: 6
+		MaxWeight: 7
 		UnloadVoice: Unload
 		UnloadCursor: exit
 	WithCargoPipsDecoration:


### PR DESCRIPTION
It's kinda weird that one tile can hold 7 infantry units, but only 6 can enter a vehicle, leaving one guy behind.

BIO's capacity remains unchanged, as it would make TUR obsolete.