### PR TITLE
Adjusted machine guns' damage dealt against armor types.

### DIFF
--- a/mods/e2140/content/ed/aircrafts/storm/weapons.yaml
+++ b/mods/e2140/content/ed/aircrafts/storm/weapons.yaml
@@ -10,6 +10,11 @@ ed_aircrafts_storm:
 	Warhead@1Dam: SpreadDamage
 		Spread: 24
 		Damage: 10
+		Versus:
+			infantry: 100
+			vehicle: 20
+			aircraft: 20
+			building: 20
 		DamageTypes: Default
 		ValidTargets: Ground, Air, Ship
 		InvalidTargets: Tree, Pipe

--- a/mods/e2140/content/ed/defenses/defense_tower/weapons.yaml
+++ b/mods/e2140/content/ed/defenses/defense_tower/weapons.yaml
@@ -10,6 +10,11 @@ ed_defenses_defense_tower:
 	Warhead@1Dam: SpreadDamage
 		Spread: 24
 		Damage: 8
+		Versus:
+			infantry: 100
+			vehicle: 20
+			aircraft: 20
+			building: 20
 		DamageTypes: Default
 		ValidTargets: Ground, Ship
 		InvalidTargets: Tree, Pipe

--- a/mods/e2140/content/ed/defenses/pillbox/weapons.yaml
+++ b/mods/e2140/content/ed/defenses/pillbox/weapons.yaml
@@ -10,6 +10,11 @@ ed_defenses_pillbox:
 	Warhead@1Dam: SpreadDamage
 		Spread: 24
 		Damage: 10
+		Versus:
+			infantry: 100
+			vehicle: 20
+			aircraft: 20
+			building: 20
 		DamageTypes: Default
 		ValidTargets: Ground, Ship
 		InvalidTargets: Tree, Pipe

--- a/mods/e2140/content/ed/infantry/a01/weapons.yaml
+++ b/mods/e2140/content/ed/infantry/a01/weapons.yaml
@@ -10,6 +10,11 @@ ed_infantry_a01_machine_gun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 24
 		Damage: 5
+		Versus:
+			infantry: 100
+			vehicle: 20
+			aircraft: 20
+			building: 20
 		DamageTypes: Default
 		ValidTargets: Ground, Ship
 		InvalidTargets: Tree, Pipe

--- a/mods/e2140/content/ed/vehicles/btti/weapons.yaml
+++ b/mods/e2140/content/ed/vehicles/btti/weapons.yaml
@@ -10,6 +10,11 @@ ed_vehicles_btti:
 	Warhead@1Dam: SpreadDamage
 		Spread: 24
 		Damage: 7
+		Versus:
+			infantry: 100
+			vehicle: 20
+			aircraft: 20
+			building: 20
 		DamageTypes: Default
 		ValidTargets: Ground, Ship
 		InvalidTargets: Tree, Pipe

--- a/mods/e2140/content/ed/vehicles/miner/weapons.yaml
+++ b/mods/e2140/content/ed/vehicles/miner/weapons.yaml
@@ -10,6 +10,11 @@ ed_vehicles_miner:
 	Warhead@1Dam: SpreadDamage
 		Spread: 24
 		Damage: 7
+		Versus:
+			infantry: 100
+			vehicle: 20
+			aircraft: 20
+			building: 20
 		DamageTypes: Default
 		ValidTargets: Ground, Ship
 		InvalidTargets: Tree, Pipe

--- a/mods/e2140/content/ucs/aircrafts/gargoil/weapons.yaml
+++ b/mods/e2140/content/ucs/aircrafts/gargoil/weapons.yaml
@@ -10,6 +10,11 @@ ucs_aircrafts_gargoil:
 	Warhead@1Dam: SpreadDamage
 		Spread: 24
 		Damage: 10
+		Versus:
+			infantry: 100
+			vehicle: 20
+			aircraft: 20
+			building: 20
 		DamageTypes: Default
 		ValidTargets: Ground, Air, Ship
 		InvalidTargets: Tree, Pipe

--- a/mods/e2140/content/ucs/defenses/little_eye/weapons.yaml
+++ b/mods/e2140/content/ucs/defenses/little_eye/weapons.yaml
@@ -10,6 +10,11 @@ ucs_defenses_little_eye:
 	Warhead@1Dam: SpreadDamage
 		Spread: 24
 		Damage: 8
+		Versus:
+			infantry: 100
+			vehicle: 20
+			aircraft: 20
+			building: 20
 		DamageTypes: Default
 		ValidTargets: Ground, Ship
 		InvalidTargets: Tree, Pipe

--- a/mods/e2140/content/ucs/infantry/silver_one/weapons.yaml
+++ b/mods/e2140/content/ucs/infantry/silver_one/weapons.yaml
@@ -9,6 +9,11 @@ ucs_infantry_silver_one:
 	Warhead@1Dam: SpreadDamage
 		Spread: 24
 		Damage: 7
+		Versus:
+			infantry: 100
+			vehicle: 20
+			aircraft: 20
+			building: 20
 		DamageTypes: Default
 		ValidTargets: Ground, Ship
 		InvalidTargets: Tree, Pipe

--- a/mods/e2140/content/ucs/vehicles/atm_500/weapons.yaml
+++ b/mods/e2140/content/ucs/vehicles/atm_500/weapons.yaml
@@ -10,6 +10,11 @@ ucs_vehicles_atm_500:
 	Warhead@1Dam: SpreadDamage
 		Spread: 24
 		Damage: 7
+		Versus:
+			infantry: 100
+			vehicle: 20
+			aircraft: 20
+			building: 20
 		DamageTypes: Default
 		ValidTargets: Ground, Ship
 		InvalidTargets: Tree, Pipe

--- a/mods/e2140/content/ucs/vehicles/miner_bt/weapons.yaml
+++ b/mods/e2140/content/ucs/vehicles/miner_bt/weapons.yaml
@@ -10,6 +10,11 @@ ucs_vehicles_miner_bt:
 	Warhead@1Dam: SpreadDamage
 		Spread: 24
 		Damage: 7
+		Versus:
+			infantry: 100
+			vehicle: 20
+			aircraft: 20
+			building: 20
 		DamageTypes: Default
 		ValidTargets: Ground, Ship
 		InvalidTargets: Tree, Pipe

--- a/mods/e2140/content/ucs/vehicles/raptor_es/weapons.yaml
+++ b/mods/e2140/content/ucs/vehicles/raptor_es/weapons.yaml
@@ -10,6 +10,11 @@ ucs_vehicles_raptor_es:
 	Warhead@1Dam: SpreadDamage
 		Spread: 24
 		Damage: 7
+		Versus:
+			infantry: 100
+			vehicle: 20
+			aircraft: 20
+			building: 20
 		DamageTypes: Default
 		ValidTargets: Ground, Ship
 		InvalidTargets: Tree, Pipe

--- a/mods/e2140/content/ucs/vehicles/t100/weapons.yaml
+++ b/mods/e2140/content/ucs/vehicles/t100/weapons.yaml
@@ -10,6 +10,11 @@ ucs_vehicles_t100:
 	Warhead@1Dam: SpreadDamage
 		Spread: 24
 		Damage: 7
+		Versus:
+			infantry: 100
+			vehicle: 20
+			aircraft: 20
+			building: 20
 		DamageTypes: Default
 		ValidTargets: Ground, Ship
 		InvalidTargets: Tree, Pipe


### PR DESCRIPTION
This change makes machine guns as useless as they are in the original game. I've run some tests in the vanilla and for example it takes for BTTI about 30 series of machine gun firing to destroy the other BTTI. This was recreated in OpenE2140.

I am not 100% sure about aircrafts as it's hard to test them in vanilla because as soon as they are being shot, they become airborne. But by the looks of the first dealt shot, it seems there's also damage reduction.