### PR TITLE
Use custom Torpedo projectile for Sharks and Russ submarines

### DIFF
--- a/OpenRA.Mods.OpenE2140/Projectiles/Torpedo.cs
+++ b/OpenRA.Mods.OpenE2140/Projectiles/Torpedo.cs
@@ -1,0 +1,47 @@
+﻿#region Copyright & License Information
+
+/*
+ * Copyright (c) The OpenE2140 Developers and Contributors
+ * This file is part of OpenE2140, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+
+#endregion
+
+using OpenRA.GameRules;
+using OpenRA.Mods.Common.Projectiles;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.OpenE2140.Projectiles;
+
+[Desc($"Modified version of {nameof(Missile)}, which makes it behave more like torpedoes in Earth 2140.")]
+public class TorpedoInfo : MissileInfo
+{
+	public override IProjectile Create(ProjectileArgs args)
+	{
+		return new Torpedo(this, args);
+	}
+}
+
+public class Torpedo : Missile
+{
+	public Torpedo(MissileInfo info, ProjectileArgs args)
+		: base(info, args)
+	{
+	}
+
+	protected override bool ShouldExplode(World world, MissileExplodeContext context)
+	{
+		// Modifies behavior of standard missile: doesn't explode, when gets close to target, if target is not (Frozen)Actor,
+		// i.e. when target is terrain, missile just passes through the target cell and continues traveling.
+		return
+			context.HitGround ||
+			((context.ProjectileArgs.GuidedTarget.Type is TargetType.Actor or TargetType.FrozenActor) && context.WithinRange) ||
+			context.RanOutOfFuel ||
+			context.HitIncompatibleTerrain ||
+			context.AirBurst;
+	}
+}

--- a/mods/e2140/content/core/rules/defaults.yaml
+++ b/mods/e2140/content/core/rules/defaults.yaml
@@ -592,6 +592,8 @@
 	Explodes:
 		Weapon: VehicleExploding
 		EmptyWeapon: VehicleExploding
+	# Block projectiles (ships should block only torpedoes, but that's not possible now).
+	BlocksProjectiles:
 	# Ships smoke when they're heavily damaged.
 	WithDamageOverlay:
 		Image: smoking
@@ -856,6 +858,12 @@
 	Explodes:
 		Weapon: VehicleExplosion
 		EmptyWeapon: VehicleExplosion
+
+# Ship husks need special behavior.
+^ShipHusk:
+	Inherits: ^Husk
+	# Ship husks also block projectiles (ships should block only torpedoes, but that's not possible now).
+	BlocksProjectiles:
 
 # Husk throws a turret if it has it.
 ^HuskThrowsTurret:

--- a/mods/e2140/content/ed/ships/kt30/rules.yaml
+++ b/mods/e2140/content/ed/ships/kt30/rules.yaml
@@ -76,7 +76,7 @@ ed_ships_kt30:
 		Description: The KT 30 is a medium-sized battleship with heavy armor-plating and heavy weapons. Its disadvantage is its low speed but its heavy armorplating and its two rocket launchers with self-guided missiles, both small and large, make it a force to be reckoned with. The KT 30 can be used to fight hostile ships or buildings that are close to shore. You can use the small rockets against air-attacks. These features gave the KT 30 the nickname “swimming castle”.
 
 ed_ships_kt30_husk:
-	Inherits@1: ^Husk
+	Inherits@1: ^ShipHusk
 	Inherits@2: ^HuskThrowsTurret
 	Inherits@3: ^HuskBurnsBigFire
 	Tooltip:

--- a/mods/e2140/content/ed/ships/shark/rules.yaml
+++ b/mods/e2140/content/ed/ships/shark/rules.yaml
@@ -43,7 +43,7 @@ ed_ships_shark:
 		Description: Its high velocity and its torpedoes make the SHARK ideal for quick attacks aimed at destroying enemy marine units. How-ever, SHARK is completely helpless against landbased or air-borne attacks.\n\nA SHARK should avoid direct confrontation and use its speed to get enough distance between itself and the enemy
 
 ed_ships_shark_husk:
-	Inherits@1: ^Husk
+	Inherits@1: ^ShipHusk
 	Inherits@2: ^HuskBurnsSmallFire
 	Tooltip:
 		Name: Husk (SHARK)

--- a/mods/e2140/content/ed/ships/shark/weapons.yaml
+++ b/mods/e2140/content/ed/ships/shark/weapons.yaml
@@ -6,7 +6,7 @@ ed_ships_shark:
 	ValidTargets: Water, Ship
 	Burst: 2
 	BurstDelays: 13
-	Projectile: Missile
+	Projectile: Torpedo
 		Speed: 160
 		Blockable: false
 		Image: projectile

--- a/mods/e2140/content/ed/ships/shark/weapons.yaml
+++ b/mods/e2140/content/ed/ships/shark/weapons.yaml
@@ -14,6 +14,7 @@ ed_ships_shark:
 		HomingActivationDelay: 9999999
 		Blockable: true
 		Gravity: 0
+		BlockingIgnoreSourceActor: true
 		BoundToTerrainType: Water
 		RangeLimit: 9999999
 		Palette:

--- a/mods/e2140/content/ed/ships/shark/weapons.yaml
+++ b/mods/e2140/content/ed/ships/shark/weapons.yaml
@@ -6,11 +6,16 @@ ed_ships_shark:
 	ValidTargets: Water, Ship
 	Burst: 2
 	BurstDelays: 13
-	Projectile: Bullet
+	Projectile: Missile
 		Speed: 160
 		Blockable: false
 		Image: projectile
 		Sequences: torpedo
+		HomingActivationDelay: 9999999
+		Blockable: true
+		Gravity: 0
+		BoundToTerrainType: Water
+		RangeLimit: 9999999
 		Palette:
 		TrailPalette:
 	Warhead@Damage: SpreadDamage

--- a/mods/e2140/content/ed/ships/wtrn/rules.yaml
+++ b/mods/e2140/content/ed/ships/wtrn/rules.yaml
@@ -41,7 +41,7 @@ ed_ships_wtrn:
 			Shore: 100
 
 ed_ships_wtrn_husk:
-	Inherits@1: ^Husk
+	Inherits@1: ^ShipHusk
 	Inherits@2: ^HuskBurnsBigFire
 	Tooltip:
 		Name: Husk (WTRN)

--- a/mods/e2140/content/ucs/ships/russ3/rules.yaml
+++ b/mods/e2140/content/ucs/ships/russ3/rules.yaml
@@ -50,7 +50,7 @@ ucs_ships_russ3:
 		Description: The RUSS III is the latest model of the reliable RUSS-series. These small, fast submarines have been used for various tasks for decades. The RUSS III is the latest version, fitted with a high-performance, low-noise motor. But what makes this submarine so special is its stealth device which makes it invisible to enemy airplanes and helicopters, even when it’s just beneath the water’s surface.\n\nIt’s conventional torpedo launcher, is enough to destroy any target moving on the water.\n\nThe RUSS III can only be seen by the enemy when it fires its torpedoes.
 
 ucs_ships_russ3_husk:
-	Inherits@1: ^Husk
+	Inherits@1: ^ShipHusk
 	Inherits@2: ^HuskBurnsSmallFire
 	Tooltip:
 		Name: Husk (RUSS 3)

--- a/mods/e2140/content/ucs/ships/russ3/weapons.yaml
+++ b/mods/e2140/content/ucs/ships/russ3/weapons.yaml
@@ -6,7 +6,7 @@ ucs_ships_russ3:
 	ValidTargets: Water, Ship
 	Burst: 2
 	BurstDelays: 13
-	Projectile: Missile
+	Projectile: Torpedo
 		Speed: 160
 		Blockable: false
 		Image: projectile

--- a/mods/e2140/content/ucs/ships/russ3/weapons.yaml
+++ b/mods/e2140/content/ucs/ships/russ3/weapons.yaml
@@ -6,11 +6,16 @@ ucs_ships_russ3:
 	ValidTargets: Water, Ship
 	Burst: 2
 	BurstDelays: 13
-	Projectile: Bullet
+	Projectile: Missile
 		Speed: 160
 		Blockable: false
 		Image: projectile
 		Sequences: torpedo
+		HomingActivationDelay: 9999999
+		Blockable: true
+		Gravity: 0
+		BoundToTerrainType: Water
+		RangeLimit: 20480
 		Palette:
 		TrailPalette:
 	Warhead@Damage: SpreadDamage

--- a/mods/e2140/content/ucs/ships/russ3/weapons.yaml
+++ b/mods/e2140/content/ucs/ships/russ3/weapons.yaml
@@ -14,6 +14,7 @@ ucs_ships_russ3:
 		HomingActivationDelay: 9999999
 		Blockable: true
 		Gravity: 0
+		BlockingIgnoreSourceActor: true
 		BoundToTerrainType: Water
 		RangeLimit: 20480
 		Palette:

--- a/mods/e2140/content/ucs/ships/ttre400/rules.yaml
+++ b/mods/e2140/content/ucs/ships/ttre400/rules.yaml
@@ -56,7 +56,7 @@ ucs_ships_ttre400:
 		Description: The TTR is a fast mine layer which can safeguard territories effectively from enemy ships and submarines by laying and moving water mines.\n\nThe only armament a TTR 400 carries are its mines, making it an easy target for the enemy. It’s only defense is to retreat, dropping mines in the water as it goes.
 
 ucs_ships_ttre400_husk:
-	Inherits@1: ^Husk
+	Inherits@1: ^ShipHusk
 	Inherits@2: ^HuskBurnsBigFire
 	Tooltip:
 		Name: Husk (TTRE 400)

--- a/mods/e2140/content/ucs/vehicles/wtp_100/rules.yaml
+++ b/mods/e2140/content/ucs/vehicles/wtp_100/rules.yaml
@@ -19,6 +19,8 @@ ucs_vehicles_wtp_100:
 		Speed: 90
 	RevealsShroud:
 		Range: 2c896
+	# Block projectiles (ships/WTP 100 should block only torpedoes, but that's not possible now).
+	BlocksProjectiles:
 	WithMoveSound:
 		Sound: 31.smp
 	# WTP 100 doesn't have move animation.
@@ -52,7 +54,7 @@ ucs_vehicles_wtp_100:
 			Shore: 100
 
 ucs_vehicles_wtp_100_husk:
-	Inherits@1: ^Husk
+	Inherits@1: ^ShipHusk
 	Inherits@2: ^HuskBurnsBigFire
 	Tooltip:
 		Name: Husk (WTP 100)


### PR DESCRIPTION
`Torpedo` projectile (based on `Missile`) makes torpedoes behave like they do in vanilla Earth 2140, i.e.:

- can be blocked by non-water terrain
- can be blocked by other actors
- can run out of fuel
- and **mainly**: when targeting water tile, they don't explode at that tile, they continue traveling until they either hit something (actor/non-water tile) or run out of fuel

Depends on two changes of `Missile` projectile in OpenRA:

OpenRA/OpenRA#21281


![opene2140_russ3_missile_blocked_by_actor](https://github.com/OpenE2140/OpenE2140/assets/119738087/7c307d9e-d29f-4037-94a3-555c4c168c04)
![opene2140_russ3_missile_blocked_by_terrain](https://github.com/OpenE2140/OpenE2140/assets/119738087/705abc27-3a36-4442-96b8-73e40f9f0bd5)
![opene2140_russ3_torpedo_continue_traveling](https://github.com/OpenE2140/OpenE2140/assets/119738087/4807e6da-72e5-4e4d-a11d-6dcccda06b30)
