### PR TITLE
Adjusted offsets for some cursors.

### DIFF
--- a/mods/e2140/chrome/cursors.yaml
+++ b/mods/e2140/chrome/cursors.yaml
@@ -40,14 +40,8 @@ Cursors:
 		guard:
 			Start: 28
 			Length: 4
-		pickup:
-			Start: 56
-			Length: 4
 		heal:
 			Start: 64
-			Length: 4
-		deliver:
-			Start: 68
 			Length: 4
 		repair:
 			Start: 72
@@ -58,21 +52,8 @@ Cursors:
 		deploy-blocked:
 			Start: 24
 			Length: 4
-
-		waterMinePlace:
-			Start: 36
-			Length: 4
 		waterMineRemove:
 			Start: 40
-			Length: 4
-		minePlace:
-			Start: 48
-			Length: 4
-		mineRemove:
-			Start: 52
-			Length: 4
-		wallPlace:
-			Start: 16
 			Length: 4
 
 		scroll-r:
@@ -89,6 +70,36 @@ Cursors:
 			Length: 4
 		plasmablast:
 			Start: 4
+			Length: 4
+
+	wallPlace_cursor.vspr:
+		wallPlace:
+			Start: 0
+			Length: 4
+
+	deliver_cursor.vspr:
+		deliver:
+			Start: 0
+			Length: 4
+
+	waterMinePlace_cursor.vspr:
+		waterMinePlace:
+			Start: 0
+			Length: 4
+
+	minePlace_cursor.vspr:
+		minePlace:
+			Start: 0
+			Length: 4
+
+	mineRemove_cursor.vspr:
+		mineRemove:
+			Start: 0
+			Length: 4
+
+	pickup_cursor.vspr:
+		pickup:
+			Start: 0
 			Length: 4
 
 	content/core/assets/repairblocked.png:

--- a/mods/e2140/virtualassets/cursors.VirtualAssets.yaml
+++ b/mods/e2140/virtualassets/cursors.VirtualAssets.yaml
@@ -1,6 +1,27 @@
 Sources:
 	SPRI1.MIX:
 
+Palettes:
+	BluePixelRemove: Merge
+		102: 0 0 0 0
+
 Generate:
+	wallPlace_cursor: BluePixelRemove
+		idle: 16-19
+			Offsets: 19:0,1
+	waterMinePlace_cursor:
+		idle: 36-39
+			Offsets: 36:1,1 37:1,1 38:0,1 39:1,1
+	minePlace_cursor:
+		idle: 48-51
+			Offsets: 50:-1,0 51:-1,0
+	mineRemove_cursor:
+		idle: 52-55
+			Offsets: 55:-1,0
+	pickup_cursor:
+		idle: 56-59
+			Offsets: 58:1,0 59:1,0
+	deliver_cursor: BluePixelRemove
+		idle: 68-71
 	repair_cursor:
 		idle: 72-75


### PR DESCRIPTION
Some cursors in vanilla have wrong offsets. This PR adjusts that. Moreover `deliver` and `wallPlace` cursors have blue stray pixels which this PR removes.