### PR TITLE
Added hovering for all aircraft units when they're airborne.

### DIFF
--- a/mods/e2140/content/core/rules/defaults.yaml
+++ b/mods/e2140/content/core/rules/defaults.yaml
@@ -528,6 +528,13 @@
 	# Render an indicator that actor is interfered.
 	WithDecoration@Interference:
 		RequiresCondition: VehicleInterfered && !airborne
+	# Aircraft units hover when they're airborne.
+	Hovers:
+		BobDistance: -10
+		MinHoveringAltitude: 0c256
+		Ticks: 3
+		FallTicks: 6
+		RiseTicks: 6
 
 # Base for all aircrafts husks
 ^CoreAircraftFallingHusk:


### PR DESCRIPTION
I noticed that in vanilla, when you order Heavy Lifter to pickup another crate when it already has one, it will fly over the crate, but it will not try to land. This reveals that the aircraft unit is hovering.

It can be also noticed for other airborne units but it's super barely visible.

I recreated this hovering animation. Note that DOS one runs faster than intended.

Vanilla (DOS):
![hover_vanilla](https://github.com/user-attachments/assets/8c24941a-9c62-4b18-b38b-aa84091db8f3)

OpenE2140:
![hover_opene2140](https://github.com/user-attachments/assets/8cc3003f-99d9-4e25-b0fb-e6a0952ef4ce)
