### PR TITLE
Changed cursor for leaving building action.

### DIFF
--- a/mods/e2140/content/core/rules/defaults.yaml
+++ b/mods/e2140/content/core/rules/defaults.yaml
@@ -179,6 +179,7 @@
 	BuildingCrew:
 		RequiresCondition: !Transforming && !IsDead
 		ExitBuildingNotification: LeavingBuilding
+		CrewExitCursor: exit
 	BuildingCrewEntrance@1:
 		EntryCell: 0,2
 	BuildingCrewEntrance@2:


### PR DESCRIPTION
Cursor `exit` fits better for this action than `deploy` one.