### PR TITLE
Changed visuals for disabled actor.

### DIFF
--- a/mods/e2140/content/core/rules/defaults.yaml
+++ b/mods/e2140/content/core/rules/defaults.yaml
@@ -827,15 +827,9 @@
 		MinHP: 0
 		MaxHP: 5
 	# Render an indicator that actor is disabled.
-	WithDecoration@Disabled:
-		Image: disabledActor-indicator
-		Sequence: idle
-		Palette:
-		Position: Top
-		ValidRelationships: Ally, Enemy, Neutral
-		Offsets:
-			VehicleInterfered: -15, 0
+	WithColoredOverlay@DisableVehicle:
 		RequiresCondition: VehicleDisabled
+		Color: 00000064
 	# Plays static sound when vehicle is disabled.
 	Voiced@Static:
 		VoiceSet: StaticVoice

--- a/mods/e2140/content/ed/vehicles/screamer/rules.yaml
+++ b/mods/e2140/content/ed/vehicles/screamer/rules.yaml
@@ -35,8 +35,6 @@ ed_vehicles_screamer:
 	-RejectsOrders:
 	-ExternalCondition@Interference:
 	-WithDecoration@Interference:
-	WithDecoration@Disabled:
-		-Offsets:
 	Encyclopedia:
 		Category: ED - Vehicles
 		Order: 12


### PR DESCRIPTION
After some thinking, I realized this lightning indicator doesn't look that great and it might be a bit annoying seeing that poping out when an actor is disabled by firearms, but not by ion weapons.

![disabledactor_indicator](https://github.com/user-attachments/assets/6cb32813-7541-401f-902f-f134012c1aa1)

So I used the simpler solution, just making an actor darker. This is common in CnC games like Generals or CnC3 (and OpenRA) and it's self-explanatory as well.

![disable](https://github.com/user-attachments/assets/776e813c-42f4-4864-a59c-1f2e8fff8d7c)
