### PR TITLE
MCU's text label is now always visable and it's green.

### DIFF
--- a/mods/e2140/content/shared/vehicles/mcu/rules.yaml
+++ b/mods/e2140/content/shared/vehicles/mcu/rules.yaml
@@ -34,9 +34,9 @@
 		Bounds: 1392, 1072, 0, 0
 	WithTextDecoration:
 		Text: MCU
-		RequiresSelection: True
 		Position: Top
 		Margin: 0,5
+		Color: 00EC00
 	# MCUs are not slower when they are damaged.
 	-GrantConditionOnDamageState@DecreasedSpeed:
 	-SpeedMultiplier:


### PR DESCRIPTION
Based on the first PvP matches.
