### PR TITLE
Added `ability` cursor.

### DIFF
--- a/mods/e2140/chrome/cursors.yaml
+++ b/mods/e2140/chrome/cursors.yaml
@@ -164,3 +164,8 @@ Cursors:
 			Length: 36
 		selfdestruct-blocked:
 			Start: 0
+
+	content/core/assets/beacon.png:
+		ability:
+			Start: 0
+			Length: 4


### PR DESCRIPTION
This PR adds `ability` cursor which is only used by beacon activity in OpenE2140 mod.

It's a more or less stopgap untill #572 is merged.