### PR TITLE
Labeled Mission Pack 1 & 2 soundtrack properly.

### DIFF
--- a/mods/e2140-content/installer/gog.yaml
+++ b/mods/e2140-content/installer/gog.yaml
@@ -36,38 +36,42 @@ gog_soundtrack_mp2: Earth 2140 Mission Pack 2 Soundtrack (GoG)
 		!Downloads/earth_2140_soundtrack.zip: e113c53dfbc690a52c150497ff3efcf36d4ca3eb
 	Install:
 		ContentPackage:
-			Name: soundtrack
+			Name: soundtrack_mp2
 			Actions:
 				ExtractZip: !Downloads/earth_2140_soundtrack.zip
-					^SupportDir|Content/e2140/music/Mission Pack 2 - Track 10.mp3: 10 - track_mp.mp3
-					^SupportDir|Content/e2140/music/Mission Pack 2 - Track 11.mp3: 11 - track_mp.mp3
-					^SupportDir|Content/e2140/music/Mission Pack 2 - Track 12.mp3: 12 - track_mp.mp3
-					^SupportDir|Content/e2140/music/Mission Pack 2 - Track 13.mp3: 13 - track_mp.mp3
-					^SupportDir|Content/e2140/music/Mission Pack 2 - Track 14.mp3: 14 - track_mp.mp3
-					^SupportDir|Content/e2140/music/Mission Pack 2 - Track 15.mp3: 15 - track_mp.mp3
-					^SupportDir|Content/e2140/music/Mission Pack 2 - Track 16.mp3: 16 - track_mp.mp3
-					^SupportDir|Content/e2140/music/Mission Pack 2 - Track 17.mp3: 17 - track_mp.mp3
-					^SupportDir|Content/e2140/music/Mission Pack 2 - Track 18.mp3: 18 - track_mp.mp3
+					^SupportDir|Content/e2140/music/Track 16 - MP2.mp3: 10 - track_mp.mp3
+					^SupportDir|Content/e2140/music/Track 17 - MP2.mp3: 11 - track_mp.mp3
+					^SupportDir|Content/e2140/music/Track 18 - MP2.mp3: 12 - track_mp.mp3
+					^SupportDir|Content/e2140/music/Track 19 - MP2.mp3: 13 - track_mp.mp3
+					^SupportDir|Content/e2140/music/Track 20 - MP2.mp3: 14 - track_mp.mp3
+					^SupportDir|Content/e2140/music/Track 21 - MP2.mp3: 15 - track_mp.mp3
+					^SupportDir|Content/e2140/music/Track 22 - MP2.mp3: 16 - track_mp.mp3
+					#^SupportDir|Content/e2140/music/Track 10 - MP1 - Big Journey.mp3: 17 - track_mp.mp3 # This is MP1 soundtrack, already included in extra zip.
+					#^SupportDir|Content/e2140/music/Track 15 - MP1 - Space.mp3: 18 - track_mp.mp3 # This is MP1 soundtrack, already included in extra zip.
 
-gog_soundtrack_extra: Earth 2140 Extra Soundtrack (GoG)
+gog_soundtrack_extra: Earth 2140 Mission Pack 1 & Extra Soundtrack (GoG)
 	Type: Gog
 		AppId: 1207658738
 	IDFiles:
 		!Downloads/earth_2140_original_ost_mp3.zip: 80b55f2ac60feae835c5cf9a376af53a2237b126
 	Install:
+		ContentPackage@soundtrack_mp1:
+			Name: soundtrack_mp1
+			Actions:
+				ExtractZip: !Downloads/earth_2140_original_ost_mp3.zip
+					^SupportDir|Content/e2140/music/Track 10 - MP1 - Big Journey.mp3: earth_2140_original_ost_mp3/12 - Big Journey.mp3
+					^SupportDir|Content/e2140/music/Track 11 - MP1 - The Hunt.mp3: earth_2140_original_ost_mp3/03 - The Hunt.mp3
+					^SupportDir|Content/e2140/music/Track 12 - MP1 - Black Tech.mp3: earth_2140_original_ost_mp3/08 - Black Tech.mp3
+					^SupportDir|Content/e2140/music/Track 13 - MP1 - Deep in the Bunker.mp3: earth_2140_original_ost_mp3/05 - Deep in the Bunker.mp3
+					^SupportDir|Content/e2140/music/Track 14 - MP1 - Bubbles' Revenge.mp3: earth_2140_original_ost_mp3/11 - Bubbles' Revenge.mp3
+					^SupportDir|Content/e2140/music/Track 15 - MP1 - Space.mp3: earth_2140_original_ost_mp3/15 - Space.mp3
 		ContentPackage@soundtrack_extra:
 			Name: soundtrack_extra
 			Actions:
 				ExtractZip: !Downloads/earth_2140_original_ost_mp3.zip
 					^SupportDir|Content/e2140/music/EARTH Theme.mp3: earth_2140_original_ost_mp3/01 - EARTH Theme.mp3
-					^SupportDir|Content/e2140/music/The Hunt.mp3: earth_2140_original_ost_mp3/03 - The Hunt.mp3
-					^SupportDir|Content/e2140/music/Deep in the Bunker.mp3: earth_2140_original_ost_mp3/05 - Deep in the Bunker.mp3
 					^SupportDir|Content/e2140/music/Before the Battle.mp3: earth_2140_original_ost_mp3/07 - Before the Battle.mp3
-					^SupportDir|Content/e2140/music/Black Tech.mp3: earth_2140_original_ost_mp3/08 - Black Tech.mp3
 					^SupportDir|Content/e2140/music/Total Control.mp3: earth_2140_original_ost_mp3/09 - Total Control.mp3
-					^SupportDir|Content/e2140/music/Bubbles' Revenge.mp3: earth_2140_original_ost_mp3/11 - Bubbles' Revenge.mp3
-					^SupportDir|Content/e2140/music/Big Journey.mp3: earth_2140_original_ost_mp3/12 - Big Journey.mp3
-					^SupportDir|Content/e2140/music/Space.mp3: earth_2140_original_ost_mp3/15 - Space.mp3
 		ContentPackage@soundtrack_vocals:
 			Name: soundtrack_vocals
 			Actions:

--- a/mods/e2140-content/installer/steam.yaml
+++ b/mods/e2140-content/installer/steam.yaml
@@ -122,25 +122,29 @@ steam_mac_de: Earth 2140 (Steam, Mac, German)
 					^SupportDir|Content/e2140/music/Track 8 - EARTH Theme.ogg: Earth 2140.app/Contents/Resources/common/music/8.ogg
 					^SupportDir|Content/e2140/music/Track 9 - Total Control.ogg: Earth 2140.app/Contents/Resources/common/music/9.ogg
 
-steam_soundtrack_extra: Earth 2140 Extra Soundtrack (Steam)
+steam_soundtrack_extra: Earth 2140 Mission Pack 1 & Extra Soundtrack (Steam)
 	Type: Steam
 		AppId: 253860
 	IDFiles:
 		Soundtrack/01. EARTH Theme.mp3: 5b5a25f65cc6815d7ca8ee8c469dfc3f7831c79f
 	Install:
+		ContentPackage@soundtrack_mp1:
+			Name: soundtrack_mp1
+			Actions:
+				Copy: .
+					^SupportDir|Content/e2140/music/Track 10 - MP1 - Big Journey.mp3: Soundtrack/12 - Big Journey.mp3
+					^SupportDir|Content/e2140/music/Track 11 - MP1 - The Hunt.mp3: Soundtrack/03 - The Hunt.mp3
+					^SupportDir|Content/e2140/music/Track 12 - MP1 - Black Tech.mp3: Soundtrack/08 - Black Tech.mp3
+					^SupportDir|Content/e2140/music/Track 13 - MP1 - Deep in the Bunker.mp3: Soundtrack/05 - Deep in the Bunker.mp3
+					^SupportDir|Content/e2140/music/Track 14 - MP1 - Bubbles' Revenge.mp3: Soundtrack/11 - Bubbles' Revenge.mp3
+					^SupportDir|Content/e2140/music/Track 15 - MP1 - Space.mp3: Soundtrack/15 - Space.mp3
 		ContentPackage@soundtrack_extra:
 			Name: soundtrack_extra
 			Actions:
 				Copy: .
 					^SupportDir|Content/e2140/music/EARTH Theme.mp3: Soundtrack/01 - EARTH Theme.mp3
-					^SupportDir|Content/e2140/music/The Hunt.mp3: Soundtrack/03 - The Hunt.mp3
-					^SupportDir|Content/e2140/music/Deep in the Bunker.mp3: Soundtrack/05 - Deep in the Bunker.mp3
 					^SupportDir|Content/e2140/music/Before the Battle.mp3: Soundtrack/07 - Before the Battle.mp3
-					^SupportDir|Content/e2140/music/Black Tech.mp3: Soundtrack/08 - Black Tech.mp3
 					^SupportDir|Content/e2140/music/Total Control.mp3: Soundtrack/09 - Total Control.mp3
-					^SupportDir|Content/e2140/music/Bubbles' Revenge.mp3: Soundtrack/11 - Bubbles' Revenge.mp3
-					^SupportDir|Content/e2140/music/Big Journey.mp3: Soundtrack/12 - Big Journey.mp3
-					^SupportDir|Content/e2140/music/Space.mp3: Soundtrack/15 - Space.mp3
 		ContentPackage@soundtrack_vocals:
 			Name: soundtrack_vocals
 			Actions:

--- a/mods/e2140-content/mod.yaml
+++ b/mods/e2140-content/mod.yaml
@@ -84,10 +84,15 @@ ModContent:
 			Identifier: music
 			TestFiles: ^SupportDir|Content/e2140/music/Track 1 - Child of 2140.ogg
 			Sources: gog, steam_en, steam_de, steam_mac_en, steam_mac_de, topwareshop_en, topwareshop_de, zoom
+		ContentPackage@soundtrack_mp1:
+			Title: Mission Pack 1 Soundtrack Music
+			Identifier: soundtrack_mp1
+			TestFiles: ^SupportDir|Content/e2140/music/Track 10 - MP1 - Big Journey.mp3
+			Sources: gog_soundtrack_extra, steam_soundtrack_extra
 		ContentPackage@soundtrack_mp2:
 			Title: Mission Pack 2 Soundtrack Music
-			Identifier: soundtrack
-			TestFiles: ^SupportDir|Content/e2140/music/Mission Pack 2 - Track 10.mp3
+			Identifier: soundtrack_mp2
+			TestFiles: ^SupportDir|Content/e2140/music/Track 16 - MP2.mp3
 			Sources: gog_soundtrack_mp2
 		ContentPackage@soundtrack_extra:
 			Title: Extra Soundtrack Music

--- a/mods/e2140/music.yaml
+++ b/mods/e2140/music.yaml
@@ -28,83 +28,80 @@ track09: Track 9 - Total Control
 	Filename: music/Track 9 - Total Control
 	Extension: ogg
 
+# Mission Pack 1 music
+
+track10: Track 10 - MP1 - Big Journey
+	Filename: music/Track 10 - MP1 - Big Journey
+	Extension: mp3
+track11: Track 11 - MP1 - The Hunt
+	Filename: music/Track 11 - MP1 - The Hunt
+	Extension: mp3
+track12: Track 12 - MP1 - Black Tech
+	Filename: music/Track 12 - MP1 - Black Tech
+	Extension: mp3
+track13: Track 13 - MP1 - Deep in the Bunker
+	Filename: music/Track 13 - MP1 - Deep in the Bunker
+	Extension: mp3
+track14: Track 14 - MP1 - Bubbles' Revenge
+	Filename: music/Track 14 - MP1 - Bubbles' Revenge
+	Extension: mp3
+track15: Track 15 - MP1 - Space
+	Filename: music/Track 15 - MP1 - Space
+	Extension: mp3
+
 # Mission Pack 2 music
 
-track10: Mission Pack 2 - Track 10
-	Filename: music/Mission Pack 2 - Track 10
+track16: Track 16 - MP2
+	Filename: music/Track 16 - MP2
 	Extension: mp3
-track11: Mission Pack 2 - Track 11
-	Filename: music/Mission Pack 2 - Track 11
+track17: Track 17 - MP2
+	Filename: music/Track 17 - MP2
 	Extension: mp3
-track12: Mission Pack 2 - Track 12
-	Filename: music/Mission Pack 2 - Track 12
+track18: Track 18 - MP2
+	Filename: music/Track 18 - MP2
 	Extension: mp3
-track13: Mission Pack 2 - Track 13
-	Filename: music/Mission Pack 2 - Track 13
+track19: Track 19 - MP2
+	Filename: music/Track 19 - MP2
 	Extension: mp3
-track14: Mission Pack 2 - Track 14
-	Filename: music/Mission Pack 2 - Track 14
+track20: Track 20 - MP2
+	Filename: music/Track 20 - MP2
 	Extension: mp3
-track15: Mission Pack 2 - Track 15
-	Filename: music/Mission Pack 2 - Track 15
+track21: Track 21 - MP2
+	Filename: music/Track 21 - MP2
 	Extension: mp3
-track16: Mission Pack 2 - Track 16
-	Filename: music/Mission Pack 2 - Track 16
-	Extension: mp3
-track17: Mission Pack 2 - Track 17
-	Filename: music/Mission Pack 2 - Track 17
-	Extension: mp3
-track18: Mission Pack 2 - Track 18
-	Filename: music/Mission Pack 2 - Track 18
+track22: Track 22 - MP2
+	Filename: music/Track 22 - MP2
 	Extension: mp3
 
 # Extra music
 
-track19: EARTH Theme
+track23: EARTH Theme
 	Filename: music/EARTH Theme
 	Extension: mp3
-track20: The Hunt
-	Filename: music/The Hunt
-	Extension: mp3
-track21: Deep in the Bunker
-	Filename: music/Deep in the Bunker
-	Extension: mp3
-track22: Before the Battle
+track24: Before the Battle
 	Filename: music/Before the Battle
 	Extension: mp3
-track23: Black Tech
-	Filename: music/Black Tech
-	Extension: mp3
-track24: Total Control
+track25: Total Control
 	Filename: music/Total Control
-	Extension: mp3
-track25: Bubbles' Revenge
-	Filename: music/Bubbles' Revenge
-	Extension: mp3
-track26: Big Journey
-	Filename: music/Big Journey
-	Extension: mp3
-track27: Space
-	Filename: music/Space
 	Extension: mp3
 
 # Vocal music
 
-track28: Child of 2140 - Vocals
+track26: Child of 2140 - Vocals
 	Filename: music/Child of 2140 - Vocals
 	Extension: mp3
-track29: Birds - Vocals
+track27: Birds - Vocals
 	Filename: music/Birds - Vocals
 	Extension: mp3
-track30: Hurricane - Vocals
+track28: Hurricane - Vocals
 	Filename: music/Hurricane - Vocals
 	Extension: mp3
-track31: Everywhere - Vocals
+track29: Everywhere - Vocals
 	Filename: music/Everywhere - Vocals
 	Extension: mp3
-track32: Hope - Vocals
+track30: Hope - Vocals
 	Filename: music/Hope - Vocals
 	Extension: mp3
-track33: 2140 - Vocals
+track31: 2140 - Vocals
 	Filename: music/2140 - Vocals
 	Extension: mp3


### PR DESCRIPTION
- `17 - track_mp.mp3` and `18 - track_mp.mp3` were commented out because they're already included in `earth_2140_original_ost_mp3.zip`.
