### PR TITLE
Enabled Explored Map checkbox by default.

### DIFF
--- a/mods/e2140/content/core/rules/player.yaml
+++ b/mods/e2140/content/core/rules/player.yaml
@@ -4,6 +4,7 @@
 	AlwaysVisible:
 	# Enable shroud and fog.
 	Shroud:
+		ExploredMapCheckboxEnabled: True
 	# Resources
 	PlayerResources:
 		ResourceValues:


### PR DESCRIPTION
By default it is a better option because players don't have to learn MP maps.
