### PR TITLE
Delayed Mine's resource crate production.

### DIFF
--- a/mods/e2140/content/shared/buildings/mine/rules.yaml
+++ b/mods/e2140/content/shared/buildings/mine/rules.yaml
@@ -15,6 +15,7 @@ shared_buildings_mine:
 		CrateSize: 200
 		RequiresCondition: !Transforming
 		PauseOnCondition: !Powered
+		Delay: 100
 	ResourceMineOverlay:
 		MiningAreaBorderColor: 8F8F00FF
 		MiningAreaBorderShape: Square # Square/Circle/None


### PR DESCRIPTION
In Earth 2140 HD it seems to be about 4s. Delay 100 makes it very similar to vanilla gameplay.

Closes #656