### PR TITLE
Adjusted starting units classes.

### DIFF
--- a/mods/e2140/content/core/fluent/rules.ftl
+++ b/mods/e2140/content/core/fluent/rules.ftl
@@ -1,6 +1,7 @@
 ## World
 options-starting-units =
     .mcu-only = MCU only
+    .economy = Economy Support
     .light-support = Light Support
     .heavy-support = Heavy Support
 

--- a/mods/e2140/content/ed/rules.yaml
+++ b/mods/e2140/content/ed/rules.yaml
@@ -10,17 +10,23 @@ World:
 		ClassName: options-starting-units.mcu-only
 		BaseActor: ed_mcu_constr_center
 		Factions: ed
-	StartingUnits@ed_default:
+	StartingUnits@ed_economy:
+		Class: economy
+		ClassName: options-starting-units.economy
+		BaseActor: ed_mcu_constr_center
+		SupportActors: shared_vehicles_bantha, shared_vehicles_bantha, shared_vehicles_bantha
+		Factions: ed
+	StartingUnits@ed_light:
 		Class: light
 		ClassName: options-starting-units.light-support
 		BaseActor: ed_mcu_constr_center
-		SupportActors: ed_vehicles_st01b, ed_vehicles_btti, ed_infantry_a01, ed_infantry_a01, ed_infantry_a01, ed_infantry_a01, ed_infantry_a01
+		SupportActors: ed_vehicles_btti, ed_vehicles_btti, ed_vehicles_st01b, ed_infantry_a01, ed_infantry_a01, ed_infantry_a01, ed_infantry_a01, ed_infantry_a01, ed_infantry_a01
 		Factions: ed
 	StartingUnits@ed_heavy:
 		Class: heavy
 		ClassName: options-starting-units.heavy-support
 		BaseActor: ed_mcu_constr_center
-		SupportActors: ed_vehicles_ht30lr, ed_vehicles_st02, ed_vehicles_mt200, ed_infantry_a02, ed_infantry_a02, ed_infantry_a02, ed_infantry_a02, ed_infantry_a02
+		SupportActors: ed_vehicles_ht30lr, ed_vehicles_ht33r, ed_vehicles_ht34j, ed_vehicles_mt200, ed_vehicles_mt200, ed_infantry_a02, ed_infantry_a02, ed_infantry_a02, ed_infantry_a02, ed_infantry_a02, ed_infantry_a02
 		Factions: ed
 
 ^EdVehicle:

--- a/mods/e2140/content/ucs/rules.yaml
+++ b/mods/e2140/content/ucs/rules.yaml
@@ -10,17 +10,23 @@ World:
 		ClassName: options-starting-units.mcu-only
 		BaseActor: ucs_mcu_prod_center
 		Factions: ucs
-	StartingUnits@ucs_default:
+	StartingUnits@ucs_economy:
+		Class: economy
+		ClassName: options-starting-units.economy
+		BaseActor: ucs_mcu_prod_center
+		SupportActors: shared_vehicles_bantha, shared_vehicles_bantha, shared_vehicles_bantha
+		Factions: ucs
+	StartingUnits@ucs_light:
 		Class: light
 		ClassName: options-starting-units.light-support
 		BaseActor: ucs_mcu_prod_center
-		SupportActors: ucs_vehicles_tiger_hellmaker, ucs_vehicles_atm_500, ucs_infantry_silver_one, ucs_infantry_silver_one, ucs_infantry_silver_one, ucs_infantry_silver_one, ucs_infantry_silver_one
+		SupportActors: ucs_vehicles_t100, ucs_vehicles_t100, ucs_vehicles_raptor_ad, ucs_infantry_silver_one, ucs_infantry_silver_one, ucs_infantry_silver_one, ucs_infantry_silver_one, ucs_infantry_silver_one, ucs_infantry_silver_one
 		Factions: ucs
 	StartingUnits@ucs_heavy:
 		Class: heavy
 		ClassName: options-starting-units.heavy-support
 		BaseActor: ucs_mcu_prod_center
-		SupportActors: ucs_vehicles_spider, ucs_vehicles_tiger_assault, ucs_vehicles_tiger_assault, ucs_infantry_silver_r, ucs_infantry_silver_r, ucs_infantry_silver_r, ucs_infantry_silver_one, ucs_infantry_silver_one
+		SupportActors: ucs_vehicles_tiger_assault, ucs_vehicles_spider, ucs_vehicles_spider_ii, ucs_vehicles_raptor_ad, ucs_vehicles_raptor_ad, ucs_infantry_silver_r, ucs_infantry_silver_r, ucs_infantry_silver_r, ucs_infantry_silver_r, ucs_infantry_silver_r, ucs_infantry_silver_r
 		Factions: ucs
 
 # Base for all UCS mechs with turrets.


### PR DESCRIPTION
Added new `Economy` class which gives 3 extra banthas.

Light class adjusted:

1. Added one extra infantry unit for both sides.
2. UCS has now two T100s and Raptor AD while ED side has now two BTTIs and one ST01B. This setup makes the beginning a bit more fair for both sides.

Heavy class adjusted:

1. Basically go nuts scenario, I added more high tier units. This mode is not really designed for "balanced" gameplay anyway.
