### PR TITLE
HT30LR - reduced rocket launcher's range to match laser beam range.

### DIFF
--- a/mods/e2140/content/ed/vehicles/ht30lr/weapons.yaml
+++ b/mods/e2140/content/ed/vehicles/ht30lr/weapons.yaml
@@ -36,7 +36,7 @@ ed_vehicles_ht30lr_laser:
 ed_vehicles_ht30lr_missiles:
 	Inherits: Smudges
 	ReloadDelay: 48
-	Range: 4c896
+	Range: 2c896 #4c896 Reduced range so HT30LR can attack ground units with both laser beams and rockets. This is a temporary solution.
 	MinRange: 0c512
 	Report: 5.smp
 	ValidTargets: Ground, Water, Ship
@@ -106,7 +106,8 @@ ed_vehicles_ht30lr_missiles:
 		InvalidTargets: Vehicle, Defense, Structure, Air, Ship, Pipe, Water
 
 ed_vehicles_ht30lr_missiles_air:
-	Inherits: ed_vehicles_st02
+	Inherits: ed_vehicles_ht30lr_missiles
 	ValidTargets: Air
+	Range: 4c896
 	Projectile: Missile
 		Inaccuracy: 2c0


### PR DESCRIPTION
Range against air remains the same.
