### PR TITLE
Fix cratered/burnt sand terrain types in temperate tileset

### DIFF
--- a/mods/e2140/tilesets/temperate.yaml
+++ b/mods/e2140/tilesets/temperate.yaml
@@ -142,10 +142,10 @@ Templates:
 		Categories: Terrain
 		Frames: 215, 216, 217, 218
 		Tiles:
-			0: Clear
-			1: Clear
-			2: Clear
-			3: Clear
+			0: Sand
+			1: Sand
+			2: Sand
+			3: Sand
 
 	# Burnt clear tiles
 	Template@702:
@@ -168,8 +168,8 @@ Templates:
 		Categories: Terrain
 		Frames: 221, 222
 		Tiles:
-			0: Clear
-			1: Clear
+			0: Sand
+			1: Sand
 
 	# Large crater made by destruction of Power Plant
 	Template@30:


### PR DESCRIPTION
Templates 701 and 703 correspond to cratered and burnt sand. In all tilesets except temperate, these have the "Sand" terrain type. This change makes temperate use "Sand" as well.