### PR TITLE
Rules changes for Dune map.

### DIFF
--- a/mods/e2140/maps/dune/rules.yaml
+++ b/mods/e2140/maps/dune/rules.yaml
@@ -1,3 +1,17 @@
 shared_mcu_water_base:
 	Buildable:
 		Prerequisites: ~disabled
+
+^CoreWorld:
+	Locomotor@vehicle:
+		TerrainSpeeds:
+			Sand: 100
+			SandEdge: 100
+	Locomotor@light_vehicle:
+		TerrainSpeeds:
+			Sand: 100
+			SandEdge: 100
+
+World:
+	MissionData:
+		Briefing: There is no movement penalty on sand.


### PR DESCRIPTION
Removed sand penalty movement for wheeled and tracked vehicles for Dune (4 player) map.
